### PR TITLE
Add source-archive script and correct cmake support

### DIFF
--- a/cmake/SourceArchive.cmake
+++ b/cmake/SourceArchive.cmake
@@ -2,7 +2,7 @@ if(SOURCE_ARCHIVE_DIR AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
   message(STATUS "Determining source archive file names")
 
   execute_process(COMMAND python ${PROJECT_SOURCE_DIR}/scripts/source-archive
-                          --release=ome-files-cpp
+                          --release=ome-qtwidgets
                           "--target=${SOURCE_ARCHIVE_DIR}"
                           --list
                           --tag=HEAD
@@ -24,7 +24,7 @@ if(SOURCE_ARCHIVE_DIR AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
                        COMMAND "${CMAKE_COMMAND}" -E make_directory
                                "${SOURCE_ARCHIVE_DIR}"
                        COMMAND python "${PROJECT_SOURCE_DIR}/scripts/source-archive"
-                               --release=ome-files-cpp
+                               --release=ome-qtwidgets
                                "--target=${SOURCE_ARCHIVE_DIR}"
                                --tag=HEAD
                        DEPENDS "${PROJECT_SOURCE_DIR}/scripts/source-archive"

--- a/scripts/source-archive
+++ b/scripts/source-archive
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from optparse import OptionParser
+import os
+import re
+from subprocess import call, check_output, CalledProcessError
+import sys
+import zipfile
+import tarfile
+import StringIO
+import platform
+
+# This script archives the base tree and repacks it into a single zip
+# which is the source release, taking care to preserve timestamps and
+# execute permissions, etc.  This is done via ZipInfo objects, and the
+# repacking is done entirely in memory so that this should work on any
+# platform irrespective of filesystem support for the archive
+# attributes.  It excludes .gitignore files at this point to avoid
+# polluting the release with version control files.
+
+GITVERSION_CMAKE = """set(OME_VERSION "%s")
+set(OME_VERSION_SHORT "%s")
+set(OME_VCS_SHORTREVISION "%s")
+set(OME_VCS_REVISION "%s")
+set(OME_VCS_DATE %s)
+set(OME_VCS_DATE_S "%s")
+"""
+
+if __name__ == "__main__":
+
+    if not os.path.exists('.git'):
+        raise Exception('Releasing is only possible from a git repository')
+
+    parser = OptionParser()
+    # Archive base name
+    parser.add_option(
+        "--release", action="store", type="string", dest="release")
+    # Destination directory
+    parser.add_option(
+        "--target", action="store", type="string", dest="target")
+    # Tag to make release from (tag or commit)
+    parser.add_option(
+        "--tag", action="store", type="string", dest="tag")
+    # List archives which will be created
+    parser.add_option(
+        "--list", action="store_true", dest="list", default=False)
+
+    (options, args) = parser.parse_args(sys.argv)
+
+    options.target = os.path.abspath(options.target)
+
+    # Get data from git for the specified tag.
+    vcsshortrevision = check_output(['git', 'log', '-1', options.tag, '--pretty=%h'])
+    vcsshortrevision.rstrip()
+    vcsrevision = check_output(['git', 'log', '-1', options.tag, '--pretty=%H']).rstrip()
+    vcsdate = check_output(['git', 'log', '-1', options.tag, '--pretty=%ai']).rstrip()
+    vcsdate_unix = check_output(['git', 'log', '-1', options.tag, '--pretty=%at']).rstrip()
+
+    try:
+        describe_exact = check_output(['git', 'describe', '--match=v[0-9]*', '--exact', options.tag], stderr=None).rstrip()
+        describe_exact_status = True;
+    except CalledProcessError:
+        describe_exact_status = False;
+
+    describe = check_output(['git', 'describe', '--match=v[0-9]*', options.tag]).rstrip()
+
+    tag_regex = 'v([0-9]+)[.]([0-9]+)[.]([0-9]+)(.*)'
+    match = re.search(tag_regex, describe)
+    major_version = match.group(1)
+    minor_version = match.group(2)
+    patch_version = match.group(3)
+    extra_version = match.group(4)
+
+    if describe_exact_status is True:
+        version = "%s.%s.%s%s" % (major_version, minor_version, patch_version, extra_version)
+        shortversion = "%s.%s.%s" % (major_version, minor_version, patch_version)
+    else:
+        version = "%s.%s.%s%s-DEV" % (major_version, minor_version, patch_version, extra_version)
+        shortversion = "%s.%s.%s-DEV" % (major_version, minor_version, patch_version)
+
+    prefix = "%s-%s" % (options.release, version)
+
+    if options.list:
+        print("%s/%s.zip" % (options.target, prefix))
+        print("%s/%s.tar.xz" % (options.target, prefix))
+        sys.exit(0)
+
+    print("Releasing tag %s as %s" % (options.tag, prefix))
+    sys.stdout.flush()
+
+    # Create base archive
+    base_archive_status = call([
+        'git', 'archive', '--format', 'zip',
+        '--prefix', "%s/" % (prefix),
+        '--output', "%s/%s-base.zip" % (options.target, prefix),
+        'HEAD'])
+    if base_archive_status != 0:
+        raise Exception('Failed to create git zip base archive')
+
+    zips = list(["%s/%s-base.zip" % (options.target, prefix)])
+
+    # Create destination zip file
+    print("  - creating %s/%s.zip" % (options.target, prefix))
+    sys.stdout.flush()
+    basezip = zipfile.ZipFile("%s/%s.zip" % (options.target, prefix), 'w')
+
+    # Repack each of the separate zips into the destination zip
+    for name in zips:
+        subzip = zipfile.ZipFile(name, 'r')
+        print("  - repacking %s" % (name))
+        sys.stdout.flush()
+        # Iterate over the ZipInfo objects from the archive
+        for info in subzip.infolist():
+            # Skip unwanted git and travis files
+            if (os.path.basename(info.filename) == '.gitignore' or
+                    os.path.basename(info.filename) == '.travis.yml'):
+                continue
+            print("Archiving: %s" % (info.filename))
+            # Repack a single zip object; preserve the metadata
+            # directly via the ZipInfo object and rewrite the content
+            # (which unfortunately requires decompression and
+            # recompression rather than a direct copy)
+            basezip.writestr(info, subzip.open(info.filename).read())
+
+        # Close zip or else the remove will fail on Windows
+        subzip.close()
+
+        # Remove repacked zip
+        os.remove(name)
+
+    # Embed release number
+    basezip.writestr(
+        "%s/cmake/GitVersion.cmake" % (prefix),
+        GITVERSION_CMAKE % (
+            version, shortversion,
+            vcsshortrevision,
+            vcsrevision,
+            vcsdate_unix, vcsdate))
+
+    # Repeat for tar archive
+    base_archive_status = call([
+        'git', 'archive', '--format', 'tar',
+        '--prefix', "%s/" % (prefix),
+        '--output', "%s/%s-base.tar" % (options.target, prefix),
+        'HEAD'])
+    if base_archive_status != 0:
+        raise Exception('Failed to create git tar base archive')
+
+    tars = list(["%s/%s-base.tar" % (options.target, prefix)])
+
+    # Create destination tar file
+    print("  - creating %s/%s.tar" % (options.target, prefix))
+    sys.stdout.flush()
+    basetar = tarfile.open("%s/%s.tar" % (options.target, prefix), 'w',
+                           format=tarfile.PAX_FORMAT)
+
+    # Repack each of the separate tars into the destination tar
+    for name in tars:
+        subtar = tarfile.open(name, 'r')
+        print("  - repacking %s" % (name))
+        sys.stdout.flush()
+        # Iterate over the TarInfo objects from the archive
+        for info in subtar.getmembers():
+            # Skip unwanted git and travis files
+            if (os.path.basename(info.name) == '.gitignore' or
+                    os.path.basename(info.name) == '.travis.yml'):
+                continue
+            print("Archiving: %s" % (info.name))
+            # Repack a single tar object; preserve the metadata
+            # directly via the TarInfo object and rewrite the content
+            basetar.addfile(info, subtar.extractfile(info.name))
+
+        # Close tar or else the remove will fail on Windows
+        subtar.close()
+
+        # Remove repacked tar
+        os.remove(name)
+
+    # Embed release number
+    cmakeversionbuf = StringIO.StringIO(GITVERSION_CMAKE % (
+        version, shortversion,
+        vcsshortrevision,
+        vcsrevision,
+        vcsdate_unix, vcsdate))
+    cmakeversion = tarfile.TarInfo("%s/cmake/GitVersion.cmake" % (prefix))
+    cmakeversion.size = cmakeversionbuf.len
+    basetar.addfile(cmakeversion, cmakeversionbuf)
+    basetar.close()
+    try:
+        try:
+            os.remove("%s/%s.tar.xz" % (options.target, prefix))
+        except OSError:
+            pass
+        call(['xz', "%s/%s.tar" % (options.target, prefix)])
+    except:
+        # This is expected to fail on Windows when xz is unavailable,
+        # but is always an error on all other platforms.
+        if platform.system() != 'Windows':
+            sys.exit(1)


### PR DESCRIPTION
This was missed from the filter-branch run and fixup.

See: e.g. https://ci.openmicroscopy.org/view/Files-DEV/job/OME-FILES-CPP-DEV-merge/BUILD_TYPE=Release,node=marlin/lastSuccessfulBuild/artifact/artefacts/sources/ome-qtwidgets-5.2.0-m2-3-gb617ae3-DEV.tar.xz