### PR TITLE
source-archive: Strip newline for git shortrevision

### DIFF
--- a/scripts/source-archive
+++ b/scripts/source-archive
@@ -52,8 +52,7 @@ if __name__ == "__main__":
     options.target = os.path.abspath(options.target)
 
     # Get data from git for the specified tag.
-    vcsshortrevision = check_output(['git', 'log', '-1', options.tag, '--pretty=%h'])
-    vcsshortrevision.rstrip()
+    vcsshortrevision = check_output(['git', 'log', '-1', options.tag, '--pretty=%h']).rstrip()
     vcsrevision = check_output(['git', 'log', '-1', options.tag, '--pretty=%H']).rstrip()
     vcsdate = check_output(['git', 'log', '-1', options.tag, '--pretty=%ai']).rstrip()
     vcsdate_unix = check_output(['git', 'log', '-1', options.tag, '--pretty=%at']).rstrip()


### PR DESCRIPTION
Correct newline stripping.

```
scripts/source-archive --release=test --target=/tmp --tag=HEAD
```

Check `cmake/GitVersion.cmake` in the tar archive.  The shortversion will now not have a trailing newline.