### PR TITLE
source-archive: Set GitVersion mtime

### DIFF
--- a/scripts/source-archive
+++ b/scripts/source-archive
@@ -7,6 +7,7 @@ import os
 import re
 from subprocess import call, check_output, CalledProcessError
 import sys
+import time
 import zipfile
 import tarfile
 import StringIO
@@ -185,6 +186,7 @@ if __name__ == "__main__":
         vcsdate_unix, vcsdate))
     cmakeversion = tarfile.TarInfo("%s/cmake/GitVersion.cmake" % (prefix))
     cmakeversion.size = cmakeversionbuf.len
+    cmakeversion.mtime = time.time()
     basetar.addfile(cmakeversion, cmakeversionbuf)
     basetar.close()
     try:


### PR DESCRIPTION
Correct  timestamp

```
scripts/source-archive --release=test --target=/tmp --tag=HEAD
```

Check `cmake/GitVersion.cmake` in the tar archive.  The version will also be the current date and time, rather than 1-1-1970.