### PR TITLE
Upgrade from OpenGL 2.0 to 3.3

### DIFF
--- a/lib/ome/qtwidgets/CMakeLists.txt
+++ b/lib/ome/qtwidgets/CMakeLists.txt
@@ -85,25 +85,25 @@ if (OME_QTOPENGL)
       gl/Image2D.h
       gl/Util.h)
 
-  set(QTWIDGETS_GL_V20_SOURCES
-      gl/v20/V20Axis2D.cpp
-      gl/v20/V20Grid2D.cpp
-      gl/v20/V20Image2D.cpp)
+  set(QTWIDGETS_GL_V33_SOURCES
+      gl/v33/V33Axis2D.cpp
+      gl/v33/V33Grid2D.cpp
+      gl/v33/V33Image2D.cpp)
 
-  set(QTWIDGETS_GL_V20_HEADERS
-      gl/v20/V20Axis2D.h
-      gl/v20/V20Grid2D.h
-      gl/v20/V20Image2D.h)
+  set(QTWIDGETS_GL_V33_HEADERS
+      gl/v33/V33Axis2D.h
+      gl/v33/V33Grid2D.h
+      gl/v33/V33Image2D.h)
 
-  set(QTWIDGETS_GLSL_V110_SOURCES
-      glsl/v110/GLFlatShader2D.cpp
-      glsl/v110/GLImageShader2D.cpp
-      glsl/v110/GLLineShader2D.cpp)
+  set(QTWIDGETS_GLSL_V330_SOURCES
+      glsl/v330/V330GLFlatShader2D.cpp
+      glsl/v330/V330GLImageShader2D.cpp
+      glsl/v330/V330GLLineShader2D.cpp)
 
-  set(QTWIDGETS_GLSL_V110_HEADERS
-      glsl/v110/GLFlatShader2D.h
-      glsl/v110/GLImageShader2D.h
-      glsl/v110/GLLineShader2D.h)
+  set(QTWIDGETS_GLSL_V330_HEADERS
+      glsl/v330/V330GLFlatShader2D.h
+      glsl/v330/V330GLImageShader2D.h
+      glsl/v330/V330GLLineShader2D.h)
 
   add_library(ome-qtwidgets
               ${QTWIDGETS_SOURCES}
@@ -111,10 +111,10 @@ if (OME_QTOPENGL)
               ${OME_QTWIDGETS_GENERATED_PRIVATE_HEADERS}
               ${QTWIDGETS_GL_SOURCES}
               ${QTWIDGETS_GL_HEADERS}
-              ${QTWIDGETS_GL_V20_SOURCES}
-              ${QTWIDGETS_GL_V20_HEADERS}
-              ${QTWIDGETS_GLSL_V110_SOURCES}
-              ${QTWIDGETS_GLSL_V110_HEADERS}
+              ${QTWIDGETS_GL_V33_SOURCES}
+              ${QTWIDGETS_GL_V33_HEADERS}
+              ${QTWIDGETS_GLSL_V330_SOURCES}
+              ${QTWIDGETS_GLSL_V330_HEADERS}
               ${ome-qtwidgets_HEADERS_MOC}
               ${ome-qtwidgets_RESOURCES})
   qt5_use_modules(ome-qtwidgets Core Gui Widgets Svg)
@@ -140,10 +140,10 @@ if (OME_QTOPENGL)
           DESTINATION ${ome_qtwidgets_includedir})
   install(FILES ${OME_QTWIDGETS_GL__HEADERS}
           DESTINATION ${ome_qtwidgets_includedir}/gl)
-  install(FILES ${OME_QTWIDGETS_GL_V20_HEADERS}
-          DESTINATION ${ome_qtwidgets_includedir}/gl/v20)
-  install(FILES ${OME_QTWIDGETS_GLSL_V110_HEADERS}
-          DESTINATION ${ome_qtwidgets_includedir}/glsl/v110)
+  install(FILES ${OME_QTWIDGETS_GL_V33_HEADERS}
+          DESTINATION ${ome_qtwidgets_includedir}/gl/v33)
+  install(FILES ${OME_QTWIDGETS_GLSL_V330_HEADERS}
+          DESTINATION ${ome_qtwidgets_includedir}/glsl/v330)
 
   # Dump header list for testing
   header_include_list_write(QTWIDGETS_HEADERS "" ome/qtwidgets ${PROJECT_BINARY_DIR}/test/ome-qtwidgets)

--- a/lib/ome/qtwidgets/GLView2D.cpp
+++ b/lib/ome/qtwidgets/GLView2D.cpp
@@ -44,9 +44,9 @@
 #include <ome/qtwidgets/gl/Util.h>
 
 #include <ome/qtwidgets/glm.h>
-#include <ome/qtwidgets/gl/v20/V20Image2D.h>
-#include <ome/qtwidgets/gl/v20/V20Grid2D.h>
-#include <ome/qtwidgets/gl/v20/V20Axis2D.h>
+#include <ome/qtwidgets/gl/v33/V33Image2D.h>
+#include <ome/qtwidgets/gl/v33/V33Grid2D.h>
+#include <ome/qtwidgets/gl/v33/V33Axis2D.h>
 
 #include <iostream>
 
@@ -273,9 +273,9 @@ namespace ome
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
       gl::check_gl("Set blend function");
 
-      image = new gl::v20::Image2D(reader, series, this);
-      axes = new gl::v20::Axis2D(reader, series, this);
-      grid = new gl::v20::Grid2D(reader, series, this);
+      image = new gl::v33::Image2D(reader, series, this);
+      axes = new gl::v33::Axis2D(reader, series, this);
+      grid = new gl::v33::Grid2D(reader, series, this);
 
       GLint max_combined_texture_image_units;
       glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_combined_texture_image_units);

--- a/lib/ome/qtwidgets/GLWindow.cpp
+++ b/lib/ome/qtwidgets/GLWindow.cpp
@@ -37,6 +37,7 @@
  */
 
 #include <cstdlib>
+#include <iostream>
 
 #include <ome/qtwidgets/GLWindow.h>
 
@@ -163,9 +164,9 @@ namespace ome
 
       if (!glcontext) {
         QSurfaceFormat format = requestedFormat();
-        // OpenGL 2.0 profile with debugging.
-        format.setVersion(2, 0);
-        format.setProfile(QSurfaceFormat::NoProfile);
+        // OpenGL 3.3 core profile with debugging.
+        format.setVersion(3, 3);
+        format.setProfile(QSurfaceFormat::CoreProfile);
         if (enableDebug)
           {
             format.setOption(QSurfaceFormat::DebugContext);
@@ -175,13 +176,12 @@ namespace ome
 
         glcontext = new QOpenGLContext(this);
         glcontext->setFormat(format);
-        glcontext->create();
+        bool valid = glcontext->create();
+        std::cerr << "Valid OpenGL context: " << valid << std::endl;
         makeCurrent();
 
         if (enableDebug)
           {
-            // The debug logger is broken on Windows for Qt 5.2 and earlier, so don't use.
-#if !defined(Q_OS_WIN) || QT_VERSION >= 0x050300
             logger = new QOpenGLDebugLogger(this);
             connect(logger, SIGNAL(messageLogged(QOpenGLDebugMessage)),
                     this, SLOT(logMessage(QOpenGLDebugMessage)),
@@ -191,7 +191,6 @@ namespace ome
                 logger->startLogging(QOpenGLDebugLogger::SynchronousLogging);
                 logger->enableMessages();
               }
-#endif // !defined(Q_OS_WIN) || QT_VERSION >= 0x050300
           }
 
         needsInitialize = true;
@@ -225,7 +224,7 @@ namespace ome
     void
     GLWindow::logMessage(QOpenGLDebugMessage message)
     {
-      qDebug() << message;
+      std::cerr << message.message().toStdString();
     }
 
   }

--- a/lib/ome/qtwidgets/GLWindow.h
+++ b/lib/ome/qtwidgets/GLWindow.h
@@ -40,7 +40,7 @@
 #define OME_QTWIDGETS_GLWINDOW_H
 
 #include <QtGui/QWindow>
-#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOpenGLFunctions_3_3_Core>
 #include <QtGui/QOpenGLDebugMessage>
 
 QT_BEGIN_NAMESPACE
@@ -63,7 +63,7 @@ namespace ome
      * content.
      */
     class GLWindow : public QWindow,
-                     protected QOpenGLFunctions
+                     protected QOpenGLFunctions_3_3_Core
     {
       Q_OBJECT
 

--- a/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -43,11 +43,6 @@
 #include <ome/qtwidgets/NavigationDock2D.h>
 #include <ome/qtwidgets/gl/Util.h>
 
-#include <ome/qtwidgets/glm.h>
-#include <ome/qtwidgets/gl/v20/V20Image2D.h>
-#include <ome/qtwidgets/gl/v20/V20Grid2D.h>
-#include <ome/qtwidgets/gl/v20/V20Axis2D.h>
-
 #include <iostream>
 
 #include <QtWidgets/QGridLayout>

--- a/lib/ome/qtwidgets/gl/Axis2D.cpp
+++ b/lib/ome/qtwidgets/gl/Axis2D.cpp
@@ -52,6 +52,7 @@ namespace ome
                      ome::files::dimension_size_type                    series,
                      QObject                                                *parent):
         QObject(parent),
+        vertices(),
         xaxis_vertices(QOpenGLBuffer::VertexBuffer),
         yaxis_vertices(QOpenGLBuffer::VertexBuffer),
         axis_elements(QOpenGLBuffer::IndexBuffer),
@@ -113,6 +114,9 @@ namespace ome
           xoff+smid+(arrowwid/2.0f), ylim[1]-arrowlen,
           xoff+smid, ylim[1]
         };
+
+        vertices.create();
+        vertices.bind();
 
         xaxis_vertices.create();
         xaxis_vertices.setUsagePattern(QOpenGLBuffer::StaticDraw);

--- a/lib/ome/qtwidgets/gl/Axis2D.h
+++ b/lib/ome/qtwidgets/gl/Axis2D.h
@@ -40,9 +40,10 @@
 #define OME_QTWIDGETS_GL_AXIS2D_H
 
 #include <QtCore/QObject>
+#include <QtGui/QOpenGLVertexArrayObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
-#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOpenGLFunctions_3_3_Core>
 
 #include <ome/files/Types.h>
 #include <ome/files/FormatReader.h>
@@ -50,7 +51,6 @@
 #include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/glm.h>
-#include <ome/qtwidgets/glsl/v110/GLFlatShader2D.h>
 
 namespace ome
 {
@@ -64,7 +64,7 @@ namespace ome
        *
        * Draws x and y axes for the specified image.
        */
-      class Axis2D : public QObject, protected QOpenGLFunctions
+      class Axis2D : public QObject, protected QOpenGLFunctions_3_3_Core
       {
         Q_OBJECT
 
@@ -121,6 +121,8 @@ namespace ome
                 glm::vec2 soff,
                 glm::vec2 slim);
 
+        /// The vertex array.
+        QOpenGLVertexArrayObject vertices;
         /// The vertices for the x axis.
         QOpenGLBuffer xaxis_vertices;
         /// The vertices for the y axis.

--- a/lib/ome/qtwidgets/gl/Grid2D.cpp
+++ b/lib/ome/qtwidgets/gl/Grid2D.cpp
@@ -110,6 +110,7 @@ namespace ome
                      ome::files::dimension_size_type                    series,
                      QObject                                                *parent):
         QObject(parent),
+        vertices(),
         grid_vertices(QOpenGLBuffer::VertexBuffer),
         grid_elements(QOpenGLBuffer::IndexBuffer),
         reader(reader),
@@ -193,6 +194,9 @@ namespace ome
                   }
               }
           }
+
+        vertices.create();
+        vertices.bind();
 
         grid_vertices.create();
         grid_vertices.setUsagePattern(QOpenGLBuffer::StaticDraw);

--- a/lib/ome/qtwidgets/gl/Grid2D.h
+++ b/lib/ome/qtwidgets/gl/Grid2D.h
@@ -40,9 +40,10 @@
 #define OME_QTWIDGETS_GL_GRID2D_H
 
 #include <QtCore/QObject>
+#include <QtGui/QOpenGLVertexArrayObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
-#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOpenGLFunctions_3_3_Core>
 
 #include <ome/files/Types.h>
 #include <ome/files/FormatReader.h>
@@ -64,7 +65,7 @@ namespace ome
        * Draws x and y gridlines for the specified image.
        */
       class Grid2D : public QObject,
-                     protected QOpenGLFunctions
+                     protected QOpenGLFunctions_3_3_Core
       {
         Q_OBJECT
 
@@ -122,6 +123,8 @@ namespace ome
         setSize(const glm::vec2& xlim,
                 const glm::vec2& ylim);
 
+        /// The vertex array.
+        QOpenGLVertexArrayObject vertices;
         /// The vertices for the grid.
         QOpenGLBuffer grid_vertices;
         /// The elements for the grid.

--- a/lib/ome/qtwidgets/gl/Image2D.cpp
+++ b/lib/ome/qtwidgets/gl/Image2D.cpp
@@ -163,7 +163,7 @@ namespace
    * If OpenGL limitations require
    */
   struct GLSetBufferVisitor : public boost::static_visitor<>,
-                              protected QOpenGLFunctions
+                              protected QOpenGLFunctions_3_3_Core
   {
     unsigned int textureid;
     TextureProperties tprop;
@@ -277,6 +277,7 @@ namespace ome
                        ome::files::dimension_size_type                    series,
                        QObject                                                *parent):
         QObject(parent),
+        vertices(),
         image_vertices(QOpenGLBuffer::VertexBuffer),
         image_texcoords(QOpenGLBuffer::VertexBuffer),
         image_elements(QOpenGLBuffer::IndexBuffer),
@@ -382,6 +383,10 @@ namespace ome
           xlim[1], ylim[1],
           xlim[0], ylim[1]
         };
+
+        if (!vertices.isCreated())
+          vertices.create();
+        vertices.bind();
 
         if (!image_vertices.isCreated())
           image_vertices.create();

--- a/lib/ome/qtwidgets/gl/Image2D.h
+++ b/lib/ome/qtwidgets/gl/Image2D.h
@@ -40,9 +40,10 @@
 #define OME_QTWIDGETS_GL_IMAGE2D_H
 
 #include <QtCore/QObject>
+#include <QtGui/QOpenGLVertexArrayObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
-#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOpenGLFunctions_3_3_Core>
 
 #include <ome/files/Types.h>
 #include <ome/files/FormatReader.h>
@@ -67,7 +68,7 @@ namespace ome
        * contrast.
        */
       class Image2D : public QObject,
-                      protected QOpenGLFunctions
+                      protected QOpenGLFunctions_3_3_Core
       {
         Q_OBJECT
 
@@ -202,6 +203,8 @@ namespace ome
         lut();
 
       protected:
+        /// The vertex array.
+        QOpenGLVertexArrayObject vertices;
         /// The image vertices.
         QOpenGLBuffer image_vertices;
         /// The image texture coordinates.

--- a/lib/ome/qtwidgets/gl/v33/V33Axis2D.cpp
+++ b/lib/ome/qtwidgets/gl/v33/V33Axis2D.cpp
@@ -36,7 +36,7 @@
  * #L%
  */
 
-#include <ome/qtwidgets/gl/v20/V20Image2D.h>
+#include <ome/qtwidgets/gl/v33/V33Axis2D.h>
 #include <ome/qtwidgets/gl/Util.h>
 
 #include <iostream>
@@ -47,57 +47,58 @@ namespace ome
   {
     namespace gl
     {
-      namespace v20
+      namespace v33
       {
 
-        Image2D::Image2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
-                         ome::files::dimension_size_type                    series,
-                         QObject                                                *parent):
-          gl::Image2D(reader, series, parent),
-          image_shader(new glsl::v110::GLImageShader2D(this))
+        Axis2D::Axis2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+                       ome::files::dimension_size_type                    series,
+                       QObject                                           *parent):
+          gl::Axis2D(reader, series, parent),
+          axis_shader(new glsl::v330::GLFlatShader2D(this))
         {
         }
 
-        Image2D::~Image2D()
+        Axis2D::~Axis2D()
         {
         }
 
         void
-        Image2D::render(const glm::mat4& mvp)
+        Axis2D::render(const glm::mat4& mvp)
         {
-          image_shader->bind();
+          axis_shader->bind();
 
-          image_shader->setMin(texmin);
-          image_shader->setMax(texmax);
-          image_shader->setCorrection(texcorr);
-          image_shader->setModelViewProjection(mvp);
+          vertices.bind();
 
-          glActiveTexture(GL_TEXTURE0);
-          check_gl("Activate texture");
-          glBindTexture(GL_TEXTURE_2D, textureid);
-          check_gl("Bind texture");
-          image_shader->setTexture(0);
-
-          glActiveTexture(GL_TEXTURE1);
-          check_gl("Activate texture");
-          glBindTexture(GL_TEXTURE_1D_ARRAY, lutid);
-          check_gl("Bind texture");
-          image_shader->setLUT(1);
-
-          image_shader->enableCoords();
-          image_shader->setCoords(image_vertices, 0, 2);
-
-          image_shader->enableTexCoords();
-          image_shader->setTexCoords(image_texcoords, 0, 2);
+          // Render x axis
+          axis_shader->setModelViewProjection(mvp);
+          axis_shader->setColour(glm::vec4(1.0, 0.0, 0.0, 1.0));
+          axis_shader->setOffset(glm::vec2(0.0, -40.0));
+          axis_shader->enableCoords();
+          axis_shader->setCoords(xaxis_vertices, 0, 2, 0);
 
           // Push each element to the vertex shader
-          image_elements.bind();
-          glDrawElements(GL_TRIANGLES, image_elements.size()/sizeof(GLushort), GL_UNSIGNED_SHORT, 0);
-          check_gl("Image2D draw elements");
+          axis_elements.bind();
+          glDrawElements(GL_TRIANGLES, axis_elements.size()/sizeof(GLushort), GL_UNSIGNED_SHORT, 0);
+          check_gl("Axis X draw elements");
 
-          image_shader->disableCoords();
-          image_shader->disableTexCoords();
-          image_shader->release();
+          axis_shader->disableCoords();
+
+          // Render y axis
+          axis_shader->bind();
+          axis_shader->setModelViewProjection(mvp);
+          axis_shader->setColour(glm::vec4(0.0, 1.0, 0.0, 1.0));
+          axis_shader->setOffset(glm::vec2(-40.0, 0.0));
+          axis_shader->enableCoords();
+          axis_shader->setCoords(yaxis_vertices, 0, 2, 0);
+
+          // Push each element to the vertex shader
+          axis_elements.bind();
+          glDrawElements(GL_TRIANGLES, axis_elements.size()/sizeof(GLushort), GL_UNSIGNED_SHORT, 0);
+          check_gl("Axis Y draw elements");
+
+          axis_shader->disableCoords();
+          vertices.release();
+          axis_shader->release();
         }
 
       }

--- a/lib/ome/qtwidgets/gl/v33/V33Axis2D.h
+++ b/lib/ome/qtwidgets/gl/v33/V33Axis2D.h
@@ -36,10 +36,18 @@
  * #L%
  */
 
-#include <ome/qtwidgets/gl/v20/V20Grid2D.h>
-#include <ome/qtwidgets/gl/Util.h>
+#ifndef OME_QTWIDGETS_GL_V33_V33AXIS2D_H
+#define OME_QTWIDGETS_GL_V33_V33AXIS2D_H
 
-#include <cmath>
+#include <QtCore/QObject>
+#include <QtGui/QOpenGLBuffer>
+#include <QtGui/QOpenGLShader>
+
+#include <ome/files/Types.h>
+#include <ome/files/FormatReader.h>
+
+#include <ome/qtwidgets/gl/Axis2D.h>
+#include <ome/qtwidgets/glsl/v330/V330GLFlatShader2D.h>
 
 namespace ome
 {
@@ -47,49 +55,57 @@ namespace ome
   {
     namespace gl
     {
-      namespace v20
+      namespace v33
       {
 
-        Grid2D::Grid2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
-                       ome::files::dimension_size_type                    series,
-                       QObject                                                *parent):
-          gl::Grid2D(reader, series, parent),
-          grid_shader(new glsl::v110::GLLineShader2D(this))
+        /**
+         * 2D (xy) axis renderer.
+         *
+         * Draws x and y axes for the specified image.
+         */
+        class Axis2D : public gl::Axis2D
         {
-        }
+          Q_OBJECT
 
-        Grid2D::~Grid2D()
-        {
-        }
+        public:
+          /**
+           * Create a 2D axis.
+           *
+           * The size and position will be taken from the specified image.
+           *
+           * @param reader the image reader.
+           * @param series the image series.
+           * @param parent the parent of this object.
+           */
+          explicit Axis2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+                          ome::files::dimension_size_type                    series,
+                          QObject                                           *parent = 0);
 
-        void
-        Grid2D::render(const glm::mat4& mvp,
-                       float zoom)
-        {
-          grid_shader->bind();
+          /// Destructor.
+          ~Axis2D();
 
-          // Render grid
-          grid_shader->setModelViewProjection(mvp);
-          grid_shader->setZoom(zoom);
+          /**
+           * Render the axis.
+           *
+           * @param mvp the model view projection matrix.
+           */
+          void
+          render(const glm::mat4& mvp);
 
-          grid_shader->enableCoords();
-          grid_shader->setCoords(grid_vertices, 0, 3, 6 * sizeof(GLfloat));
-
-          grid_shader->enableColour();
-          grid_shader->setColour(grid_vertices, reinterpret_cast<const GLfloat *>(0)+3, 3, 6 * sizeof(GLfloat));
-
-          // Push each element to the vertex shader
-          grid_elements.bind();
-          glDrawElements(GL_LINES, grid_elements.size()/sizeof(GLushort), GL_UNSIGNED_SHORT, 0);
-          check_gl("Grid draw elements");
-
-          grid_shader->disableColour();
-          grid_shader->disableCoords();
-
-          grid_shader->release();
-        }
+        private:
+          /// The shader program for axis rendering.
+          glsl::v330::GLFlatShader2D *axis_shader;
+        };
 
       }
     }
   }
 }
+
+#endif // OME_QTWIDGETS_GL_V33_V33AXIS2D_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/lib/ome/qtwidgets/gl/v33/V33Grid2D.h
+++ b/lib/ome/qtwidgets/gl/v33/V33Grid2D.h
@@ -36,19 +36,18 @@
  * #L%
  */
 
-#ifndef OME_QTWIDGETS_GL_V20_V20GRID2D_H
-#define OME_QTWIDGETS_GL_V20_V20GRID2D_H
+#ifndef OME_QTWIDGETS_GL_V33_V33GRID2D_H
+#define OME_QTWIDGETS_GL_V33_V33GRID2D_H
 
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
-#include <QtGui/QOpenGLFunctions>
 
 #include <ome/files/Types.h>
 #include <ome/files/FormatReader.h>
 
 #include <ome/qtwidgets/gl/Grid2D.h>
-#include <ome/qtwidgets/glsl/v110/GLLineShader2D.h>
+#include <ome/qtwidgets/glsl/v330/V330GLLineShader2D.h>
 
 namespace ome
 {
@@ -56,7 +55,7 @@ namespace ome
   {
     namespace gl
     {
-      namespace v20
+      namespace v33
       {
 
         /**
@@ -80,7 +79,7 @@ namespace ome
            */
           explicit Grid2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
                           ome::files::dimension_size_type                    series,
-                          QObject                                                *parent = 0);
+                          QObject                                           *parent = 0);
 
           /// Destructor.
           ~Grid2D();
@@ -99,7 +98,7 @@ namespace ome
 
         private:
           /// The shader program for grid shading.
-          glsl::v110::GLLineShader2D *grid_shader;
+          glsl::v330::GLLineShader2D *grid_shader;
         };
 
       }
@@ -107,7 +106,7 @@ namespace ome
   }
 }
 
-#endif // OME_QTWIDGETS_GL_V20_V20GRID2D_H
+#endif // OME_QTWIDGETS_GL_V33_V33GRID2D_H
 
 /*
  * Local Variables:

--- a/lib/ome/qtwidgets/gl/v33/V33Image2D.h
+++ b/lib/ome/qtwidgets/gl/v33/V33Image2D.h
@@ -36,70 +36,76 @@
  * #L%
  */
 
-#include <ome/qtwidgets/gl/v20/V20Axis2D.h>
-#include <ome/qtwidgets/gl/Util.h>
+#ifndef OME_QTWIDGETS_GL_V33_V33IMAGE2D_H
+#define OME_QTWIDGETS_GL_V33_V33IMAGE2D_H
 
-#include <iostream>
+#include <QtCore/QObject>
+#include <QtGui/QOpenGLBuffer>
+#include <QtGui/QOpenGLShader>
+
+#include <ome/files/Types.h>
+#include <ome/files/FormatReader.h>
+
+#include <ome/qtwidgets/gl/Image2D.h>
+#include <ome/qtwidgets/glsl/v330/V330GLImageShader2D.h>
 
 namespace ome
 {
   namespace qtwidgets
   {
+    /// OpenGL rendering.
     namespace gl
     {
-      namespace v20
+      /// OpenGL v2.0 (compatibility profile).
+      namespace v33
       {
 
-        Axis2D::Axis2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
-                       ome::files::dimension_size_type                    series,
-                       QObject                                                *parent):
-          gl::Axis2D(reader, series, parent),
-          axis_shader(new glsl::v110::GLFlatShader2D(this))
+        /**
+         * 2D (xy) image renderer.
+         *
+         * Draws the specified image, using a user-selectable plane.
+         *
+         * The render is greyscale with a per-channel min/max for linear
+         * contrast.
+         */
+        class Image2D : public gl::Image2D
         {
-        }
+          Q_OBJECT
 
-        Axis2D::~Axis2D()
-        {
-        }
+        public:
+          /**
+           * Create a 2D image.
+           *
+           * The size and position will be taken from the specified image.
+           *
+           * @param reader the image reader.
+           * @param series the image series.
+           * @param parent the parent of this object.
+           */
+          explicit Image2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+                           ome::files::dimension_size_type                    series,
+                           QObject                                           *parent = 0);
 
-        void
-        Axis2D::render(const glm::mat4& mvp)
-        {
-          axis_shader->bind();
+          /// Destructor.
+          virtual ~Image2D();
 
-          // Render x axis
-          axis_shader->setModelViewProjection(mvp);
-          axis_shader->setColour(glm::vec4(1.0, 0.0, 0.0, 1.0));
-          axis_shader->setOffset(glm::vec2(0.0, -40.0));
-          axis_shader->enableCoords();
-          axis_shader->setCoords(xaxis_vertices, 0, 2, 0);
+          void
+          render(const glm::mat4& mvp);
 
-          // Push each element to the vertex shader
-          axis_elements.bind();
-          glDrawElements(GL_TRIANGLES, axis_elements.size()/sizeof(GLushort), GL_UNSIGNED_SHORT, 0);
-          check_gl("Axis X draw elements");
-
-          axis_shader->disableCoords();
-
-          // Render y axis
-          axis_shader->bind();
-          axis_shader->setModelViewProjection(mvp);
-          axis_shader->setColour(glm::vec4(0.0, 1.0, 0.0, 1.0));
-          axis_shader->setOffset(glm::vec2(-40.0, 0.0));
-          axis_shader->enableCoords();
-          axis_shader->setCoords(yaxis_vertices, 0, 2, 0);
-
-          // Push each element to the vertex shader
-          axis_elements.bind();
-          glDrawElements(GL_TRIANGLES, axis_elements.size()/sizeof(GLushort), GL_UNSIGNED_SHORT, 0);
-          check_gl("Axis Y draw elements");
-
-          axis_shader->disableCoords();
-
-          axis_shader->release();
-        }
+        private:
+          /// The shader program for image rendering.
+          glsl::v330::GLImageShader2D *image_shader;
+        };
 
       }
     }
   }
 }
+
+#endif // OME_QTWIDGETS_GL_V33_V33IMAGE2D_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/lib/ome/qtwidgets/glsl/v330/V330GLFlatShader2D.cpp
+++ b/lib/ome/qtwidgets/glsl/v330/V330GLFlatShader2D.cpp
@@ -37,7 +37,7 @@
  */
 
 #include <ome/qtwidgets/glm.h>
-#include <ome/qtwidgets/glsl/v110/GLLineShader2D.h>
+#include <ome/qtwidgets/glsl/v330/V330GLFlatShader2D.h>
 #include <ome/qtwidgets/gl/Util.h>
 
 #include <iostream>
@@ -50,37 +50,38 @@ namespace ome
   {
     namespace glsl
     {
-      namespace v110
+      namespace v330
       {
 
-        GLLineShader2D::GLLineShader2D(QObject *parent):
+        GLFlatShader2D::GLFlatShader2D(QObject *parent):
           QOpenGLShaderProgram(parent),
           vshader(),
           fshader(),
           attr_coords(),
-          attr_colour(),
+          uniform_colour(),
+          uniform_offset(),
           uniform_mvp()
         {
           initializeOpenGLFunctions();
 
           vshader = new QOpenGLShader(QOpenGLShader::Vertex, this);
           vshader->compileSourceCode
-            ("#version 110\n"
+            ("#version 330 core\n"
              "\n"
-             "attribute vec3 coord2d;\n"
-             "attribute vec3 colour;\n"
-             "varying vec4 f_colour;\n"
+             "uniform vec4 colour;\n"
+             "uniform vec2 offset;\n"
              "uniform mat4 mvp;\n"
-             "uniform float zoom;\n"
              "\n"
-             "void log10(in float v1, out float v2) { v2 = log2(v1) * 0.30103; }\n"
+             "layout (location = 0) in vec2 coord2d;\n"
+             "\n"
+             "out VertexData\n"
+             "{\n"
+             "  vec4 f_colour;\n"
+             "} outData;\n"
              "\n"
              "void main(void) {\n"
-             "  gl_Position = mvp * vec4(coord2d[0], coord2d[1], -2.0, 1.0);\n"
-             "  // Logistic function offset by LOD and correction factor to set the transition points\n"
-             "  float logzoom;\n"
-             "  log10(zoom, logzoom);\n"
-             "  f_colour = vec4(colour, 1.0 / (1.0 + pow(10.0,((-logzoom-1.0+coord2d[2])*30.0))));\n"
+             "  gl_Position = mvp * vec4(coord2d+offset, 2.0, 1.0);\n"
+             "  outData.f_colour = colour;\n"
              "}\n");
           if (!vshader->isCompiled())
             {
@@ -89,16 +90,21 @@ namespace ome
 
           fshader = new QOpenGLShader(QOpenGLShader::Fragment, this);
           fshader->compileSourceCode
-            ("#version 110\n"
+            ("#version 330 core\n"
              "\n"
-             "varying vec4 f_colour;\n"
+             "in VertexData\n"
+             "{\n"
+             "  vec4 f_colour;\n"
+             "} inData;\n"
+             "\n"
+             "out vec4 outputColour;\n"
              "\n"
              "void main(void) {\n"
-             "  gl_FragColor = f_colour;\n"
+             "  outputColour = inData.f_colour;\n"
              "}\n");
           if (!fshader->isCompiled())
             {
-              std::cerr << "Failed to compile fragment shader\n" << fshader->log().toStdString() << std::endl;
+              std::cerr << "V330GLFlatShader2D: Failed to compile fragment shader\n" << fshader->log().toStdString() << std::endl;
             }
 
           addShader(vshader);
@@ -107,55 +113,56 @@ namespace ome
 
           if (!isLinked())
             {
-              std::cerr << "Failed to link shader program\n" << log().toStdString() << std::endl;
+              std::cerr << "V330GLFlatShader2D: Failed to link shader program\n" << log().toStdString() << std::endl;
             }
 
           attr_coords = attributeLocation("coord2d");
           if (attr_coords == -1)
-            std::cerr << "Failed to bind coordinate location" << std::endl;
+            std::cerr << "V330GLFlatShader2D: Failed to bind coordinate location" << std::endl;
 
-          attr_colour = attributeLocation("colour");
-          if (attr_coords == -1)
-            std::cerr << "Failed to bind colour location" << std::endl;
+          uniform_colour = uniformLocation("colour");
+          if (uniform_colour == -1)
+            std::cerr << "V330GLFlatShader2D: Failed to bind colour" << std::endl;
+
+          uniform_offset = uniformLocation("offset");
+          if (uniform_offset == -1)
+            std::cerr << "V330GLFlatShader2D: Failed to bind offset" << std::endl;
 
           uniform_mvp = uniformLocation("mvp");
           if (uniform_mvp == -1)
-            std::cerr << "Failed to bind transform" << std::endl;
-
-          uniform_zoom = uniformLocation("zoom");
-          if (uniform_zoom == -1)
-            std::cerr << "Failed to bind zoom factor" << std::endl;
+            std::cerr << "V330GLFlatShader2D: Failed to bind transform" << std::endl;
         }
 
-        GLLineShader2D::~GLLineShader2D()
+        GLFlatShader2D::~GLFlatShader2D()
         {
         }
 
         void
-        GLLineShader2D::enableCoords()
+        GLFlatShader2D::enableCoords()
         {
           enableAttributeArray(attr_coords);
         }
 
         void
-        GLLineShader2D::disableCoords()
+        GLFlatShader2D::disableCoords()
         {
           disableAttributeArray(attr_coords);
         }
 
         void
-        GLLineShader2D::setCoords(const GLfloat *offset,
+        GLFlatShader2D::setCoords(const GLfloat *offset,
                                   int            tupleSize,
                                   int            stride)
         {
           setAttributeArray(attr_coords, offset, tupleSize, stride);
+          check_gl("Set flatcoords");
         }
 
         void
-        GLLineShader2D::setCoords(QOpenGLBuffer& coords,
-                                  const GLfloat *offset,
-                                  int            tupleSize,
-                                  int            stride)
+        GLFlatShader2D::setCoords(QOpenGLBuffer&  coords,
+                                  const GLfloat  *offset,
+                                  int             tupleSize,
+                                  int             stride)
         {
           coords.bind();
           setCoords(offset, tupleSize, stride);
@@ -163,48 +170,24 @@ namespace ome
         }
 
         void
-        GLLineShader2D::enableColour()
+        GLFlatShader2D::setColour(const glm::vec4& colour)
         {
-          enableAttributeArray(attr_colour);
+          glUniform4fv(uniform_colour, 1, glm::value_ptr(colour));
+          check_gl("Set flat uniform colour");
         }
 
         void
-        GLLineShader2D::disableColour()
+        GLFlatShader2D::setOffset(const glm::vec2& offset)
         {
-          disableAttributeArray(attr_colour);
+          glUniform2fv(uniform_offset, 1, glm::value_ptr(offset));
+          check_gl("Set flat uniform offset");
         }
 
         void
-        GLLineShader2D::setColour(const GLfloat *offset,
-                                  int            tupleSize,
-                                  int            stride)
-        {
-          setAttributeArray(attr_colour, offset, tupleSize, stride);
-        }
-
-        void
-        GLLineShader2D::setColour(QOpenGLBuffer&  colour,
-                                  const GLfloat  *offset,
-                                  int             tupleSize,
-                                  int             stride)
-        {
-          colour.bind();
-          setColour(offset, tupleSize, stride);
-          colour.release();
-        }
-
-        void
-        GLLineShader2D::setModelViewProjection(const glm::mat4& mvp)
+        GLFlatShader2D::setModelViewProjection(const glm::mat4& mvp)
         {
           glUniformMatrix4fv(uniform_mvp, 1, GL_FALSE, glm::value_ptr(mvp));
-          check_gl("Set line uniform mvp");
-        }
-
-        void
-        GLLineShader2D::setZoom(float zoom)
-        {
-          glUniform1f(uniform_zoom, zoom);
-          check_gl("Set line zoom level");
+          check_gl("Set flat uniform mvp");
         }
 
       }

--- a/lib/ome/qtwidgets/glsl/v330/V330GLFlatShader2D.h
+++ b/lib/ome/qtwidgets/glsl/v330/V330GLFlatShader2D.h
@@ -36,12 +36,12 @@
  * #L%
  */
 
-#ifndef OME_QTWIDGETS_GLSL_V110_GLLINESHADER2D_H
-#define OME_QTWIDGETS_GLSL_V110_GLLINESHADER2D_H
+#ifndef OME_QTWIDGETS_GLSL_V330_V330GLFLATSHADER2D_H
+#define OME_QTWIDGETS_GLSL_V330_V330GLFLATSHADER2D_H
 
 #include <QOpenGLShader>
 #include <QOpenGLBuffer>
-#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOpenGLFunctions_3_3_Core>
 
 #include <ome/qtwidgets/glm.h>
 
@@ -51,13 +51,13 @@ namespace ome
   {
     namespace glsl
     {
-      namespace v110
+      namespace v330
       {
 
         /**
-         * 2D line shader program.
+         * 2D flat (solid fill) shader program.
          */
-        class GLLineShader2D : public QOpenGLShaderProgram, protected QOpenGLFunctions
+        class GLFlatShader2D : public QOpenGLShaderProgram, protected QOpenGLFunctions_3_3_Core
         {
           Q_OBJECT
 
@@ -67,10 +67,10 @@ namespace ome
            *
            * @param parent the parent of this object.
            */
-          explicit GLLineShader2D(QObject *parent = 0);
+          explicit GLFlatShader2D(QObject *parent = 0);
 
           /// Destructor.
-          ~GLLineShader2D();
+          ~GLFlatShader2D();
 
           /// @copydoc GLImageShader2D::enableCoords()
           void
@@ -86,60 +86,32 @@ namespace ome
                     int            tupleSize,
                     int            stride = 0);
 
-          /// @copydoc GLImageShader2D::setCoords(QOpenGLBuffer&, const GLfloat *, int, int)
+          /// @copydoc GLImageShader2D::setCoords(QOpenGLBuffer&, const GLfloat*, int, int)
           void
           setCoords(QOpenGLBuffer&  coords,
                     const GLfloat  *offset,
                     int             tupleSize,
                     int             stride = 0);
 
-          /// Enable colour array.
-          void
-          enableColour();
-
-          /// Disable colour array.
-          void
-          disableColour();
-
           /**
-           * Set colours from array.
+           * Set fill colour.
            *
-           * @param offset data offset if using a buffer object otherwise
-           * the colour values.
-           * @param tupleSize the tuple size of the data.
-           * @param stride the stride of the data.
+           * @param colour the RGBA fill colour.
            */
           void
-          setColour(const GLfloat *offset,
-                    int            tupleSize,
-                    int            stride = 0);
+          setColour(const glm::vec4& colour);
 
           /**
-           * Set colours from buffer object.
+           * Set xy offset in model space.
            *
-           * @param colours the colour values; null if using a buffer
-           * object.
-           * @param offset the offset into the colours buffer.
-           * @param tupleSize the tuple size of the data.
-           * @param stride the stride of the data.
+           * @param offset the offset to apply to the model.
            */
           void
-          setColour(QOpenGLBuffer&  colours,
-                    const GLfloat  *offset,
-                    int             tupleSize,
-                    int             stride = 0);
+          setOffset(const glm::vec2& offset);
 
           /// @copydoc GLImageShader2D::setModelViewProjection(const glm::mat4& mvp)
           void
           setModelViewProjection(const glm::mat4& mvp);
-
-          /**
-           * Set zoom level.
-           *
-           * @param zoom the zoom level.
-           */
-          void
-          setZoom(float zoom);
 
         private:
           /// @copydoc GLImageShader2D::vshader
@@ -149,12 +121,12 @@ namespace ome
 
           /// @copydoc GLImageShader2D::attr_coords
           int attr_coords;
-          /// Vertex colour attribute
-          int attr_colour;
+          /// Fill colour uniform.
+          int uniform_colour;
+          /// Model offset uniform.
+          int uniform_offset;
           /// @copydoc GLImageShader2D::uniform_mvp
           int uniform_mvp;
-          /// Zoom uniform.
-          int uniform_zoom;
         };
 
       }
@@ -162,7 +134,7 @@ namespace ome
   }
 }
 
-#endif // OME_QTWIDGETS_GLSL_V110_GLLINESHADER2D_H
+#endif // OME_QTWIDGETS_GLSL_V330_V330GLFLATSHADER2D_H
 
 /*
  * Local Variables:

--- a/lib/ome/qtwidgets/glsl/v330/V330GLImageShader2D.h
+++ b/lib/ome/qtwidgets/glsl/v330/V330GLImageShader2D.h
@@ -36,12 +36,12 @@
  * #L%
  */
 
-#ifndef OME_QTWIDGETS_GLSL_V110_GLIMAGESHADER2D_H
-#define OME_QTWIDGETS_GLSL_V110_GLIMAGESHADER2D_H
+#ifndef OME_QTWIDGETS_GLSL_V330_V330GLIMAGESHADER2D_H
+#define OME_QTWIDGETS_GLSL_V330_V330GLIMAGESHADER2D_H
 
 #include <QOpenGLShader>
 #include <QOpenGLBuffer>
-#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOpenGLFunctions_3_3_Core>
 
 #include <ome/files/Types.h>
 
@@ -55,14 +55,14 @@ namespace ome
     namespace glsl
     {
       /// GLSL v1.10 compatible.
-      namespace v110
+      namespace v330
       {
 
         /**
          * 2D image shader program (simple, up to three channels).
          */
         class GLImageShader2D : public QOpenGLShaderProgram,
-                                protected QOpenGLFunctions
+                                protected QOpenGLFunctions_3_3_Core
         {
           Q_OBJECT
 
@@ -233,7 +233,7 @@ namespace ome
   }
 }
 
-#endif // OME_QTWIDGETS_GLSL_V110_GLIMAGESHADER2D_H
+#endif // OME_QTWIDGETS_GLSL_V330_V330GLIMAGESHADER2D_H
 
 /*
  * Local Variables:

--- a/lib/ome/qtwidgets/glsl/v330/V330GLLineShader2D.h
+++ b/lib/ome/qtwidgets/glsl/v330/V330GLLineShader2D.h
@@ -36,12 +36,12 @@
  * #L%
  */
 
-#ifndef OME_QTWIDGETS_GLSL_V110_GLFLATSHADER2D_H
-#define OME_QTWIDGETS_GLSL_V110_GLFLATSHADER2D_H
+#ifndef OME_QTWIDGETS_GLSL_V330_V330GLLINESHADER2D_H
+#define OME_QTWIDGETS_GLSL_V330_V330GLLINESHADER2D_H
 
 #include <QOpenGLShader>
 #include <QOpenGLBuffer>
-#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOpenGLFunctions_3_3_Core>
 
 #include <ome/qtwidgets/glm.h>
 
@@ -51,13 +51,14 @@ namespace ome
   {
     namespace glsl
     {
-      namespace v110
+      namespace v330
       {
 
         /**
-         * 2D flat (solid fill) shader program.
+         * 2D line shader program.
          */
-        class GLFlatShader2D : public QOpenGLShaderProgram, protected QOpenGLFunctions
+        class GLLineShader2D : public QOpenGLShaderProgram,
+                               protected QOpenGLFunctions_3_3_Core
         {
           Q_OBJECT
 
@@ -67,10 +68,10 @@ namespace ome
            *
            * @param parent the parent of this object.
            */
-          explicit GLFlatShader2D(QObject *parent = 0);
+          explicit GLLineShader2D(QObject *parent = 0);
 
           /// Destructor.
-          ~GLFlatShader2D();
+          ~GLLineShader2D();
 
           /// @copydoc GLImageShader2D::enableCoords()
           void
@@ -82,31 +83,64 @@ namespace ome
 
           /// @copydoc GLImageShader2D::setCoords(const GLfloat*, int, int)
           void
-          setCoords(const GLfloat *offset, int tupleSize, int stride = 0);
+          setCoords(const GLfloat *offset,
+                    int            tupleSize,
+                    int            stride = 0);
 
-          /// @copydoc GLImageShader2D::setCoords(QOpenGLBuffer&, const GLfloat*, int, int)
+          /// @copydoc GLImageShader2D::setCoords(QOpenGLBuffer&, const GLfloat *, int, int)
           void
-          setCoords(QOpenGLBuffer& coords, const GLfloat *offset, int tupleSize, int stride = 0);
+          setCoords(QOpenGLBuffer&  coords,
+                    const GLfloat  *offset,
+                    int             tupleSize,
+                    int             stride = 0);
+
+          /// Enable colour array.
+          void
+          enableColour();
+
+          /// Disable colour array.
+          void
+          disableColour();
 
           /**
-           * Set fill colour.
+           * Set colours from array.
            *
-           * @param colour the RGBA fill colour.
+           * @param offset data offset if using a buffer object otherwise
+           * the colour values.
+           * @param tupleSize the tuple size of the data.
+           * @param stride the stride of the data.
            */
           void
-          setColour(const glm::vec4& colour);
+          setColour(const GLfloat *offset,
+                    int            tupleSize,
+                    int            stride = 0);
 
           /**
-           * Set xy offset in model space.
+           * Set colours from buffer object.
            *
-           * @param offset the offset to apply to the model.
+           * @param colours the colour values; null if using a buffer
+           * object.
+           * @param offset the offset into the colours buffer.
+           * @param tupleSize the tuple size of the data.
+           * @param stride the stride of the data.
            */
           void
-          setOffset(const glm::vec2& offset);
+          setColour(QOpenGLBuffer&  colours,
+                    const GLfloat  *offset,
+                    int             tupleSize,
+                    int             stride = 0);
 
           /// @copydoc GLImageShader2D::setModelViewProjection(const glm::mat4& mvp)
           void
           setModelViewProjection(const glm::mat4& mvp);
+
+          /**
+           * Set zoom level.
+           *
+           * @param zoom the zoom level.
+           */
+          void
+          setZoom(float zoom);
 
         private:
           /// @copydoc GLImageShader2D::vshader
@@ -116,12 +150,12 @@ namespace ome
 
           /// @copydoc GLImageShader2D::attr_coords
           int attr_coords;
-          /// Fill colour uniform.
-          int uniform_colour;
-          /// Model offset uniform.
-          int uniform_offset;
+          /// Vertex colour attribute
+          int attr_colour;
           /// @copydoc GLImageShader2D::uniform_mvp
           int uniform_mvp;
+          /// Zoom uniform.
+          int uniform_zoom;
         };
 
       }
@@ -129,7 +163,7 @@ namespace ome
   }
 }
 
-#endif // OME_QTWIDGETS_GLSL_V110_GLFLATSHADER2D_H
+#endif // OME_QTWIDGETS_GLSL_V330_V330GLLINESHADER2D_H
 
 /*
  * Local Variables:

--- a/libexec/view/Window.cpp
+++ b/libexec/view/Window.cpp
@@ -36,10 +36,13 @@
  * #L%
  */
 
-#include <view/Window.h>
-
+// Include first to avoid clash with Windows headers pulled in via
+// QtCore/qt_windows.h; they define VOID and HALFTONE which clash with
+// the TIFF enums.
 #include <ome/files/FormatReader.h>
 #include <ome/files/in/OMETIFFReader.h>
+
+#include <view/Window.h>
 
 #include <ome/compat/memory.h>
 

--- a/libexec/view/Window.cpp
+++ b/libexec/view/Window.cpp
@@ -101,7 +101,7 @@ namespace view
     viewResetAction = new QAction(tr("&Reset"), this);
     viewResetAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_R));
     viewResetAction->setStatusTip(tr("Reset the current view"));
-    QIcon reset_icon(QString((iconpath / "actions/ome-reset2d.svg").c_str()));
+    QIcon reset_icon(QString((iconpath / "actions/ome-reset2d.svg").string().c_str()));
     viewResetAction->setIcon(reset_icon);
     viewResetAction->setEnabled(false);
     connect(viewResetAction, SIGNAL(triggered()), this, SLOT(view_reset()));
@@ -110,7 +110,7 @@ namespace view
     viewZoomAction->setCheckable(true);
     viewZoomAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Z));
     viewZoomAction->setStatusTip(tr("Zoom the current view"));
-    QIcon zoom_icon(QString((iconpath / "actions/ome-zoom2d.svg").c_str()));
+    QIcon zoom_icon(QString((iconpath / "actions/ome-zoom2d.svg").string().c_str()));
     viewZoomAction->setIcon(zoom_icon);
     viewZoomAction->setEnabled(false);
     connect(viewZoomAction, SIGNAL(triggered()), this, SLOT(view_zoom()));
@@ -119,7 +119,7 @@ namespace view
     viewPanAction->setCheckable(true);
     viewPanAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_P));
     viewPanAction->setStatusTip(tr("Pan the current view"));
-    QIcon pan_icon(QString((iconpath / "actions/ome-pan2d.svg").c_str()));
+    QIcon pan_icon(QString((iconpath / "actions/ome-pan2d.svg").string().c_str()));
     viewPanAction->setIcon(pan_icon);
     viewPanAction->setEnabled(false);
     connect(viewPanAction, SIGNAL(triggered()), this, SLOT(view_pan()));
@@ -128,7 +128,7 @@ namespace view
     viewRotateAction->setCheckable(true);
     viewRotateAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_T));
     viewRotateAction->setStatusTip(tr("Rotate the current view"));
-    QIcon rotate_icon(QString((iconpath / "actions/ome-rotate2d.svg").c_str()));
+    QIcon rotate_icon(QString((iconpath / "actions/ome-rotate2d.svg").string().c_str()));
     viewRotateAction->setIcon(rotate_icon);
     viewRotateAction->setEnabled(false);
     connect(viewRotateAction, SIGNAL(triggered()), this, SLOT(view_rotate()));


### PR DESCRIPTION
This is something I did months ago prior to the repository split, but I had time this evening to redo for the split repository.  The reason for doing this was because @sbesson mentioned last week it would be nice to bump the version to drop the milestone number for our next release, and this is the only change I had planned at all for the foreseeable future.

The main change is that it increases the minimum requirement from GL2 hardware to GL3 hardware.  In practice, this means from 15 year old hardware to 9 year old hardware, so the actual practical impact is going to be minimal, particularly since this isn't end-user-focussed at present; it's primarily for internal testing.  On the software side, GL3 is supported by all of Windows, MacOS and contemporary Linux distributions, so shouldn't impact testing internally.  It will mean older Linux distributions won't be able to run without updated drivers though, but this only applies to the older open source drivers; any nvidia/amd driver will support it without trouble.

This switches from the old GL2 API to a restricted subset containing only "modern" GL functions, known as a "Core Profile".  This is much cleaner, dropping all the obsolete and unwanted functions, and is also compatible across versions so means it's possible to use in programs using other versions of the core profile. e.g. different GLSL versions.  The main change in this PR, other than the mechanical version renaming/renumbering, is to update the GLSL shader programs to the "V330" version used by GL3.3.  The main benefit from doing this, other than modernising and cleaning the codebase, is that it gives us access to geometry shaders, which might be useful for prototyping ROI rendering when we want to explore 3D ROIs and a more modern ROI model.  You'll probably notice there are no changes to our use of the GL API: we were already using only "modern" GL even with GL2, but that's now enforced rather than being by convention alone.

Other changes:

- Use of Vertex Array Objects (VAOs) is required with 3.3 core, so enable
- Drop Windows workaround for an old Qt version
- Add a couple of Windows fixes for current Qt/Boost versions

--------

Testing:

Mac: https://ci.openmicroscopy.org/view/Files-DEV/job/OME-FILES-CPP-DEV-merge/BUILD_TYPE=Release,node=marlin/lastSuccessfulBuild/artifact/

Linux: no CI builds until we get Ubuntu 16.04 in the CI system

```
[clone ome-qtwidgets, merge this PR]
[clone ome-cmake-superbuild]
cmake -G Ninja -Dome-qtwidgets-dir=/path/to/ome-qtwidgets -Dbuild-packages=ome-qtwidgets -Dbuild-prerequisites=OFF -Dome-superbuild_BUILD_gtest=ON /path/to/ome-cmake-superbuild
ninja
./superbuild-install/bin/ome-files view
```

Then open a greyscale OME-TIFF and it should display.


I've tested this on:

- Windows/VS2015/AMD R9 390 - builds and runs
- Windows/VS2013/AMD R9 390 - builds and runs
- MacOSX/AMD Radeon- builds and runs
- Windows/VS2013/Intel Iris - builds and runs
- Linux/Ubuntu 16.04/Intel Iris - builds and runs
- Linux/Ubuntu 16.04/AMD R9 390 - builds, fails to run [Ubuntu driver bug; unrelated to the PR]