### PR TITLE
Windows header portability checks and fixes

### DIFF
--- a/cmake/HeaderTest.cmake
+++ b/cmake/HeaderTest.cmake
@@ -95,7 +95,19 @@ function(header_test_from_file component library path)
       string(REPLACE "${headerdir}/" "" include ${include})
       string(REGEX REPLACE "\\.h$" "-${repeat}.cpp" genheader ${genheader})
       string(REGEX REPLACE "[/.-]" "_" safeheader ${include})
-      string(CONFIGURE "#include <@include@>
+      unset(ome_system_include)
+      if (repeat EQUAL 1)
+        if (MSVC)
+          set(ome_system_include "#include <windows.h>")
+        endif()
+        if (UNIX)
+          set(ome_system_include "#include <unistd.h>")
+        endif()
+      endif()
+
+      string(CONFIGURE "@ome_system_include@
+
+#include <@include@>
 
 #include <ome/test/test.h>
 

--- a/lib/ome/qtwidgets/CMakeLists.txt
+++ b/lib/ome/qtwidgets/CMakeLists.txt
@@ -34,144 +34,138 @@
 # policies, either expressed or implied, of any organization.
 # #L%
 
-if (OME_QTOPENGL)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config-internal.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/config-internal.h @ONLY)
 
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config-internal.h.in
-                 ${CMAKE_CURRENT_BINARY_DIR}/config-internal.h @ONLY)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-  set(CMAKE_AUTOMOC ON)
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(QTWIDGETS_SOURCES
+    GLContainer.cpp
+    GLWindow.cpp
+    GLView2D.cpp
+    module.cpp
+    NavigationDock2D.cpp
+    TexelProperties.cpp)
 
-  set(QTWIDGETS_SOURCES
-      GLContainer.cpp
-      GLWindow.cpp
-      GLView2D.cpp
-      module.cpp
-      NavigationDock2D.cpp
-      TexelProperties.cpp)
+set(QTWIDGETS_HEADERS
+    GLContainer.h
+    GLWindow.h
+    GLView2D.h
+    glm.h
+    module.h
+    NavigationDock2D.h
+    TexelProperties.h)
 
-  set(QTWIDGETS_HEADERS
-      GLContainer.h
-      GLWindow.h
-      GLView2D.h
-      glm.h
-      module.h
-      NavigationDock2D.h
-      TexelProperties.h)
+set(OME_QTWIDGETS_GENERATED_PRIVATE_HEADERS
+    ${CMAKE_CURRENT_BINARY_DIR}/config-internal.h)
 
-  set(OME_QTWIDGETS_GENERATED_PRIVATE_HEADERS
-      ${CMAKE_CURRENT_BINARY_DIR}/config-internal.h)
+set(QTWIDGETS_GL_SOURCES
+    gl/Axis2D.cpp
+    gl/Grid2D.cpp
+    gl/Image2D.cpp
+    gl/Util.cpp)
 
-  set(QTWIDGETS_GL_SOURCES
-      gl/Axis2D.cpp
-      gl/Grid2D.cpp
-      gl/Image2D.cpp
-      gl/Util.cpp)
+set(QTWIDGETS_GL_HEADERS
+    gl/Axis2D.h
+    gl/Grid2D.h
+    gl/Image2D.h
+    gl/Util.h)
 
-  set(QTWIDGETS_GL_HEADERS
-      gl/Axis2D.h
-      gl/Grid2D.h
-      gl/Image2D.h
-      gl/Util.h)
+set(QTWIDGETS_GL_V33_SOURCES
+    gl/v33/V33Axis2D.cpp
+    gl/v33/V33Grid2D.cpp
+    gl/v33/V33Image2D.cpp)
 
-  set(QTWIDGETS_GL_V33_SOURCES
-      gl/v33/V33Axis2D.cpp
-      gl/v33/V33Grid2D.cpp
-      gl/v33/V33Image2D.cpp)
+set(QTWIDGETS_GL_V33_HEADERS
+    gl/v33/V33Axis2D.h
+    gl/v33/V33Grid2D.h
+    gl/v33/V33Image2D.h)
 
-  set(QTWIDGETS_GL_V33_HEADERS
-      gl/v33/V33Axis2D.h
-      gl/v33/V33Grid2D.h
-      gl/v33/V33Image2D.h)
+set(QTWIDGETS_GLSL_V330_SOURCES
+    glsl/v330/V330GLFlatShader2D.cpp
+    glsl/v330/V330GLImageShader2D.cpp
+    glsl/v330/V330GLLineShader2D.cpp)
 
-  set(QTWIDGETS_GLSL_V330_SOURCES
-      glsl/v330/V330GLFlatShader2D.cpp
-      glsl/v330/V330GLImageShader2D.cpp
-      glsl/v330/V330GLLineShader2D.cpp)
+set(QTWIDGETS_GLSL_V330_HEADERS
+    glsl/v330/V330GLFlatShader2D.h
+    glsl/v330/V330GLImageShader2D.h
+    glsl/v330/V330GLLineShader2D.h)
 
-  set(QTWIDGETS_GLSL_V330_HEADERS
-      glsl/v330/V330GLFlatShader2D.h
-      glsl/v330/V330GLImageShader2D.h
-      glsl/v330/V330GLLineShader2D.h)
+add_library(ome-qtwidgets
+            ${QTWIDGETS_SOURCES}
+            ${QTWIDGETS_HEADERS}
+            ${OME_QTWIDGETS_GENERATED_PRIVATE_HEADERS}
+            ${QTWIDGETS_GL_SOURCES}
+            ${QTWIDGETS_GL_HEADERS}
+            ${QTWIDGETS_GL_V33_SOURCES}
+            ${QTWIDGETS_GL_V33_HEADERS}
+            ${QTWIDGETS_GLSL_V330_SOURCES}
+            ${QTWIDGETS_GLSL_V330_HEADERS}
+            ${ome-qtwidgets_HEADERS_MOC}
+            ${ome-qtwidgets_RESOURCES})
+qt5_use_modules(ome-qtwidgets Core Gui Widgets Svg)
 
-  add_library(ome-qtwidgets
-              ${QTWIDGETS_SOURCES}
-              ${QTWIDGETS_HEADERS}
-              ${OME_QTWIDGETS_GENERATED_PRIVATE_HEADERS}
-              ${QTWIDGETS_GL_SOURCES}
-              ${QTWIDGETS_GL_HEADERS}
-              ${QTWIDGETS_GL_V33_SOURCES}
-              ${QTWIDGETS_GL_V33_HEADERS}
-              ${QTWIDGETS_GLSL_V330_SOURCES}
-              ${QTWIDGETS_GLSL_V330_HEADERS}
-              ${ome-qtwidgets_HEADERS_MOC}
-              ${ome-qtwidgets_RESOURCES})
-  qt5_use_modules(ome-qtwidgets Core Gui Widgets Svg)
+target_include_directories(ome-qtwidgets PUBLIC
+                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
+                           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/lib>
+                           $<BUILD_INTERFACE:${OPENGL_INCLUDE_DIR}>
+                           $<BUILD_INTERFACE:${GLM_INCLUDE_DIR}>)
 
-  target_include_directories(ome-qtwidgets PUBLIC
-                             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
-                             $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/lib>
-                             $<BUILD_INTERFACE:${OPENGL_INCLUDE_DIR}>
-                             $<BUILD_INTERFACE:${GLM_INCLUDE_DIR}>)
+target_link_libraries(ome-qtwidgets OME::Files
+                      Boost::filesystem
+                      ${OPENGL_gl_LIBRARY} ${TIFF_LIBRARIES})
 
-  target_link_libraries(ome-qtwidgets OME::Files
-                        Boost::filesystem
-                        ${OPENGL_gl_LIBRARY} ${TIFF_LIBRARIES})
+set_target_properties(ome-qtwidgets PROPERTIES VERSION ${OME_VERSION_SHORT})
 
-  set_target_properties(ome-qtwidgets PROPERTIES VERSION ${OME_VERSION_SHORT})
+add_library(OME::QtWidgets ALIAS ome-qtwidgets)
 
-  add_library(OME::QtWidgets ALIAS ome-qtwidgets)
-
-  if(WIN32)
-    set(ome_qtwidgets_config_dir "cmake")
-  else()
-    set(ome_qtwidgets_config_dir "${CMAKE_INSTALL_LIBDIR}/cmake/OMEQtWidgets")
-  endif()
-
-  install(TARGETS ome-qtwidgets
-          EXPORT OMEQtWidgetsInternal
-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          COMPONENT "runtime"
-          INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-  install(EXPORT OMEQtWidgetsInternal
-          DESTINATION "${ome_qtwidgets_config_dir}"
-          NAMESPACE "ome_qtwidgets_"
-          COMPONENT "development")
-
-  include(CMakePackageConfigHelpers)
-  configure_package_config_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/OMEQtWidgetsConfig.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfig.cmake"
-    INSTALL_DESTINATION "${ome_qtwidgets_config_dir}")
-  write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfigVersion.cmake
-    VERSION "${PROJECT_VERSION}"
-    COMPATIBILITY SameMajorVersion)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfig.cmake
-                ${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfigVersion.cmake
-          DESTINATION "${ome_qtwidgets_config_dir}"
-          COMPONENT "development")
-
-  set(ome_qtwidgets_includedir "${CMAKE_INSTALL_INCLUDEDIR}/ome/qtwidgets")
-
-  install(FILES ${OME_QTWIDGETS_HEADERS}
-          DESTINATION ${ome_qtwidgets_includedir}
-          COMPONENT "development")
-  install(FILES ${OME_QTWIDGETS_GL__HEADERS}
-          DESTINATION ${ome_qtwidgets_includedir}/gl
-          COMPONENT "development")
-  install(FILES ${OME_QTWIDGETS_GL_V33_HEADERS}
-          DESTINATION ${ome_qtwidgets_includedir}/gl/v33
-          COMPONENT "development")
-  install(FILES ${OME_QTWIDGETS_GLSL_V330_HEADERS}
-          DESTINATION ${ome_qtwidgets_includedir}/glsl/v330
-          COMPONENT "development")
-
-  # Dump header list for testing
-  header_include_list_write(QTWIDGETS_HEADERS "" ome/qtwidgets ${PROJECT_BINARY_DIR}/test/ome-qtwidgets)
-
+if(WIN32)
+  set(ome_qtwidgets_config_dir "cmake")
 else()
-  message(WARNING "Not building Qt widgets and view program; Qt5.2, OpenGL or glm not found, or explicitly disabled")
+  set(ome_qtwidgets_config_dir "${CMAKE_INSTALL_LIBDIR}/cmake/OMEQtWidgets")
 endif()
+
+install(TARGETS ome-qtwidgets
+        EXPORT OMEQtWidgetsInternal
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT "runtime"
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(EXPORT OMEQtWidgetsInternal
+        DESTINATION "${ome_qtwidgets_config_dir}"
+        NAMESPACE "ome_qtwidgets_"
+        COMPONENT "development")
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/OMEQtWidgetsConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfig.cmake"
+  INSTALL_DESTINATION "${ome_qtwidgets_config_dir}")
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfigVersion.cmake
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY SameMajorVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/OMEQtWidgetsConfigVersion.cmake
+        DESTINATION "${ome_qtwidgets_config_dir}"
+        COMPONENT "development")
+
+set(ome_qtwidgets_includedir "${CMAKE_INSTALL_INCLUDEDIR}/ome/qtwidgets")
+
+install(FILES ${OME_QTWIDGETS_HEADERS}
+        DESTINATION ${ome_qtwidgets_includedir}
+        COMPONENT "development")
+install(FILES ${OME_QTWIDGETS_GL__HEADERS}
+        DESTINATION ${ome_qtwidgets_includedir}/gl
+        COMPONENT "development")
+install(FILES ${OME_QTWIDGETS_GL_V33_HEADERS}
+        DESTINATION ${ome_qtwidgets_includedir}/gl/v33
+        COMPONENT "development")
+install(FILES ${OME_QTWIDGETS_GLSL_V330_HEADERS}
+        DESTINATION ${ome_qtwidgets_includedir}/glsl/v330
+        COMPONENT "development")
+
+# Dump header list for testing
+header_include_list_write(QTWIDGETS_HEADERS "" ome/qtwidgets ${PROJECT_BINARY_DIR}/test/ome-qtwidgets)

--- a/libexec/view/CMakeLists.txt
+++ b/libexec/view/CMakeLists.txt
@@ -34,39 +34,35 @@
 # policies, either expressed or implied, of any organization.
 # #L%
 
-if (OME_QTOPENGL)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-  set(CMAKE_AUTOMOC ON)
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(view_SOURCES
+    view.cpp
+    Window.cpp)
 
-  set(view_SOURCES
-      view.cpp
-      Window.cpp)
+set(view_HEADERS
+    Window.h)
 
-  set(view_HEADERS
-      Window.h)
+add_executable(view
+               ${view_SOURCES}
+               ${view_HEADERS}
+               ${view_HEADERS_MOC}
+               ${view_RESOURCES})
 
-  add_executable(view
-                 ${view_SOURCES}
-                 ${view_HEADERS}
-                 ${view_HEADERS_MOC}
-                 ${view_RESOURCES})
+qt5_use_modules(view Core Gui Widgets Svg)
 
-  qt5_use_modules(view Core Gui Widgets Svg)
+target_include_directories(view PUBLIC
+                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/libexec>
+                           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/libexec>
+                           $<BUILD_INTERFACE:${OPENGL_INCLUDE_DIR}>
+                           $<BUILD_INTERFACE:${GLM_INCLUDE_DIR}>)
 
-  target_include_directories(view PUBLIC
-                             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/libexec>
-                             $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/libexec>
-                             $<BUILD_INTERFACE:${OPENGL_INCLUDE_DIR}>
-                             $<BUILD_INTERFACE:${GLM_INCLUDE_DIR}>)
+target_link_libraries(view OME::Files OME::QtWidgets)
 
-  target_link_libraries(view OME::Files OME::QtWidgets)
-
-  install(TARGETS view RUNTIME
-          DESTINATION ${OME_QTWIDGETS_INSTALL_PKGLIBEXECDIR}
-          PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                      GROUP_READ GROUP_EXECUTE
-                      WORLD_READ WORLD_EXECUTE
-          COMPONENT "runtime")
-
-endif()
+install(TARGETS view RUNTIME
+        DESTINATION ${OME_QTWIDGETS_INSTALL_PKGLIBEXECDIR}
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        COMPONENT "runtime")

--- a/libexec/view/Window.cpp
+++ b/libexec/view/Window.cpp
@@ -51,7 +51,12 @@
 #include <ome/qtwidgets/GLContainer.h>
 #include <ome/qtwidgets/module.h>
 
-#include <QtWidgets>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMenuBar>
+#include <QtWidgets/QToolBar>
+#include <QtWidgets/QFileDialog>
 
 using namespace ome::qtwidgets;
 using ome::files::dimension_size_type;

--- a/test/ome-qtwidgets/CMakeLists.txt
+++ b/test/ome-qtwidgets/CMakeLists.txt
@@ -34,7 +34,7 @@
 # policies, either expressed or implied, of any organization.
 # #L%
 
-if(OME_QTOPENGL AND BUILD_TESTS)
+if(BUILD_TESTS)
 
   if(extended-tests)
     header_test_from_file(ome-qtwidgets ome-qtwidgets ome/qtwidgets)


### PR DESCRIPTION
See: https://github.com/ome/ome-common-cpp/pull/22

- Add header checks (no source changes needed)
- Make build unconditional now the build problems are fixed
- Minor header cleanup

Note whitespace diff: https://github.com/ome/ome-qtwidgets/pull/9/files?w=1