### PR TITLE
Basic C++11 features

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,8 +1,3 @@
-# Try to put the compiler into the most recent standard mode.  This
-# will generally have the most features, and will remove the need for
-# Boost fallbacks if native implementations are available.
-option(cxxstd-autodetect "Enable C++14 features if possible, otherwise fall back to C++11, C++03 or C++98" OFF)
-
 # These are annoyingly verbose, produce false positives or don't work
 # nicely with all supported compiler versions, so are disabled unless
 # explicitly enabled.

--- a/lib/ome/qtwidgets/GLView2D.cpp
+++ b/lib/ome/qtwidgets/GLView2D.cpp
@@ -74,7 +74,7 @@ namespace ome
   namespace qtwidgets
   {
 
-    GLView2D::GLView2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+    GLView2D::GLView2D(std::shared_ptr<ome::files::FormatReader>  reader,
                        ome::files::dimension_size_type                    series,
                        QWidget                                                * /* parent */):
       GLWindow(),
@@ -109,7 +109,7 @@ namespace ome
       return QSize(800, 600);
     }
 
-    ome::compat::shared_ptr<ome::files::FormatReader>
+    std::shared_ptr<ome::files::FormatReader>
     GLView2D::getReader()
     {
       return reader;

--- a/lib/ome/qtwidgets/GLView2D.h
+++ b/lib/ome/qtwidgets/GLView2D.h
@@ -39,9 +39,9 @@
 #ifndef OME_QTWIDGETS_GLVIEW2D_H
 #define OME_QTWIDGETS_GLVIEW2D_H
 
-#include <ome/files/FormatReader.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <ome/files/FormatReader.h>
 
 #include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/GLWindow.h>
@@ -85,7 +85,7 @@ namespace ome
        * @param series the image series.
        * @param parent the parent of this object.
        */
-      GLView2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+      GLView2D(std::shared_ptr<ome::files::FormatReader>  reader,
                ome::files::dimension_size_type                    series,
                QWidget                                                *parent = 0);
 
@@ -177,7 +177,7 @@ namespace ome
        *
        * @returns the reader.
        */
-      ome::compat::shared_ptr<ome::files::FormatReader>
+      std::shared_ptr<ome::files::FormatReader>
       getReader();
 
       /**
@@ -458,7 +458,7 @@ namespace ome
       /// Grid to render.
       gl::Grid2D *grid;
       /// The image reader.
-      ome::compat::shared_ptr<ome::files::FormatReader> reader;
+      std::shared_ptr<ome::files::FormatReader> reader;
       /// The image series.
       ome::files::dimension_size_type series;
     };

--- a/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -131,7 +131,7 @@ namespace ome
     }
 
     void
-    NavigationDock2D::setReader(ome::compat::shared_ptr<ome::files::FormatReader> reader,
+    NavigationDock2D::setReader(std::shared_ptr<ome::files::FormatReader> reader,
                                 ome::files::dimension_size_type                   series,
                                 ome::files::dimension_size_type                   plane)
     {

--- a/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -38,6 +38,7 @@
 
 #include <QtGui/QMouseEvent>
 
+#include <array>
 #include <cmath>
 
 #include <ome/qtwidgets/NavigationDock2D.h>
@@ -223,7 +224,7 @@ namespace ome
               dimension_size_type mt = reader->getModuloT().size();
               dimension_size_type mc = reader->getModuloC().size();
 
-              ome::compat::array<dimension_size_type, 3> coords(reader->getZCTCoords(plane));
+              std::array<dimension_size_type, 3> coords(reader->getZCTCoords(plane));
               reader->setSeries(oldseries);
 
               // Effective and modulo dimension positions

--- a/lib/ome/qtwidgets/NavigationDock2D.h
+++ b/lib/ome/qtwidgets/NavigationDock2D.h
@@ -39,9 +39,9 @@
 #ifndef OME_QTWIDGETS_NAVIGATIONDOCK2D_H
 #define OME_QTWIDGETS_NAVIGATIONDOCK2D_H
 
-#include <ome/files/FormatReader.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <ome/files/FormatReader.h>
 
 #include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/GLWindow.h>
@@ -91,7 +91,7 @@ namespace ome
        * @param plane the image plane.
        */
       void
-      setReader(ome::compat::shared_ptr<ome::files::FormatReader> reader,
+      setReader(std::shared_ptr<ome::files::FormatReader> reader,
                 ome::files::dimension_size_type                   series = 0,
                 ome::files::dimension_size_type                   plane = 0);
 
@@ -156,7 +156,7 @@ namespace ome
 
     private:
       /// The image reader.
-      ome::compat::shared_ptr<ome::files::FormatReader> reader;
+      std::shared_ptr<ome::files::FormatReader> reader;
       /// The image series.
       ome::files::dimension_size_type series;
       /// The image plane.

--- a/lib/ome/qtwidgets/TexelProperties.cpp
+++ b/lib/ome/qtwidgets/TexelProperties.cpp
@@ -54,7 +54,7 @@ namespace ome
 
 #define INTERNALFORMAT_CASE(maR, maProperty, maType)                    \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::internal_format; \
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::maType>::internal_format; \
           break;
 
     GLenum
@@ -74,7 +74,7 @@ namespace ome
 
 #define EXTERNALFORMAT_CASE(maR, maProperty, maType)                    \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::external_format; \
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::maType>::external_format; \
           break;
 
     GLenum
@@ -94,7 +94,7 @@ namespace ome
 
 #define EXTERNALTYPE_CASE(maR, maProperty, maType)                      \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::external_type; \
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::maType>::external_type; \
           break;
 
     GLint
@@ -114,7 +114,7 @@ namespace ome
 
 #define FALLBACKTYPE_CASE(maR, maProperty, maType)                      \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::fallback_pixeltype; \
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::maType>::fallback_pixeltype; \
           break;
 
     ::ome::xml::model::enums::PixelType
@@ -134,7 +134,7 @@ namespace ome
 
 #define CONVERSION_CASE(maR, maProperty, maType)                        \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::conversion_required; \
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::maType>::conversion_required; \
           break;
 
     bool
@@ -154,7 +154,7 @@ namespace ome
 
 #define NORMALIZATION_CASE(maR, maProperty, maType)                     \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::normalization_required; \
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::maType>::normalization_required; \
           break;
 
     bool
@@ -174,7 +174,7 @@ namespace ome
 
 #define MINIFICATION_CASE(maR, maProperty, maType)                      \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::minification_filter; \
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::maType>::minification_filter; \
           break;
 
     GLint
@@ -193,7 +193,7 @@ namespace ome
 
 #define MAGNIFICATION_CASE(maR, maProperty, maType)                     \
         case ::ome::xml::model::enums::PixelType::maType:               \
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::magnification_filter; \
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::maType>::magnification_filter; \
           break;
 
     GLint

--- a/lib/ome/qtwidgets/TexelProperties.h
+++ b/lib/ome/qtwidgets/TexelProperties.h
@@ -86,8 +86,8 @@ namespace ome
 
     /// Properties of INT8 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::INT8> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::INT8>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::INT8> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::INT8>
     {
       /// Internal pixel format (single 8-bit channel).
       static const GLenum internal_format = GL_R8;
@@ -109,8 +109,8 @@ namespace ome
 
     /// Properties of INT16 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::INT16> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::INT16>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::INT16> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::INT16>
     {
       /// Internal pixel format (single 16-bit channel).
       static const GLenum internal_format = GL_R16;
@@ -132,8 +132,8 @@ namespace ome
 
     /// Properties of INT32 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::INT32> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::INT32>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::INT32> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::INT32>
     {
       /// Internal pixel format (single 16-bit channel; note precision loss).
       static const GLenum internal_format = GL_R16;
@@ -155,8 +155,8 @@ namespace ome
 
     /// Properties of UINT8 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::UINT8> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::UINT8> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::UINT8>
     {
       /// Internal pixel format (single 8-bit channel).
       static const GLenum internal_format = GL_R8;
@@ -178,8 +178,8 @@ namespace ome
 
     /// Properties of UINT16 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::UINT16> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::UINT16> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::UINT16>
     {
       /// Internal pixel format (single 16-bit channel).
       static const GLenum internal_format = GL_R16;
@@ -201,8 +201,8 @@ namespace ome
 
     /// Properties of UINT32 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::UINT32> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::UINT32> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::UINT32>
     {
       /// Internal pixel format (single 16-bit channel; note precision loss).
       static const GLenum internal_format = GL_R16;
@@ -224,8 +224,8 @@ namespace ome
 
     /// Properties of FLOAT texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::FLOAT> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>
     {
       /// Internal pixel format (single 32-bit float channel).
       static const GLenum internal_format = GL_R32F;
@@ -247,8 +247,8 @@ namespace ome
 
     /// Properties of DOUBLE texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>
     {
       /// Internal pixel format (single 32-bit float channel; note precision loss).
       static const GLenum internal_format = GL_R32F;
@@ -270,8 +270,8 @@ namespace ome
 
     /// Properties of BIT texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::BIT> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::BIT> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::BIT>
     {
       /// Internal pixel format (single 8-bit float channel).
       static const GLenum internal_format = GL_R8;
@@ -293,8 +293,8 @@ namespace ome
 
     /// Properties of COMPLEX texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::COMPLEXFLOAT> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::COMPLEXFLOAT>
     {
       /// Internal pixel format (double 32-bit float channels).
       static const GLenum internal_format = GL_RG32F;
@@ -316,8 +316,8 @@ namespace ome
 
     /// Properties of DOUBLECOMPLEX texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE> :
-      public ome::files::PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::COMPLEXDOUBLE> :
+      public ome::files::PixelProperties<::ome::xml::model::enums::PixelType::COMPLEXDOUBLE>
     {
       /// Internal pixel format (double 32-bit float channels; note precision loss).
       static const GLenum internal_format = GL_RG32F;

--- a/lib/ome/qtwidgets/gl/Axis2D.cpp
+++ b/lib/ome/qtwidgets/gl/Axis2D.cpp
@@ -91,7 +91,8 @@ namespace ome
         GLfloat xoff(static_cast<GLfloat>(soff[0]));
         GLfloat yoff(static_cast<GLfloat>(soff[1]));
 
-        GLfloat xaxis_vertices_a[] = {
+        const std::array<GLfloat, 14> xaxis_vertices_a
+        {
           // Arrow shaft
           xlim[0], yoff+slim[0],
           xlim[1]-arrowlen, yoff+slim[0],
@@ -103,7 +104,8 @@ namespace ome
           xlim[1], yoff+smid
         };
 
-        GLfloat yaxis_vertices_a[] = {
+        const std::array<GLfloat, 14> yaxis_vertices_a
+        {
           // Arrow shaft
           xoff+slim[1], ylim[0],
           xoff+slim[1], ylim[1]-arrowlen,
@@ -121,14 +123,15 @@ namespace ome
         xaxis_vertices.create();
         xaxis_vertices.setUsagePattern(QOpenGLBuffer::StaticDraw);
         xaxis_vertices.bind();
-        xaxis_vertices.allocate(xaxis_vertices_a, sizeof(xaxis_vertices_a));
+        xaxis_vertices.allocate(xaxis_vertices_a.data(), sizeof(GLfloat) * xaxis_vertices_a.size());
 
         yaxis_vertices.create();
         yaxis_vertices.setUsagePattern(QOpenGLBuffer::StaticDraw);
         yaxis_vertices.bind();
-        yaxis_vertices.allocate(yaxis_vertices_a, sizeof(yaxis_vertices_a));
+        yaxis_vertices.allocate(yaxis_vertices_a.data(), sizeof(GLfloat) * yaxis_vertices_a.size());
 
-        GLushort axis_elements_a[] = {
+        std::array<GLushort, 9> axis_elements_a
+        {
           // Arrow shaft
           0,  1,  2,
           2,  3,  0,
@@ -139,7 +142,7 @@ namespace ome
         axis_elements.create();
         axis_elements.setUsagePattern(QOpenGLBuffer::StaticDraw);
         axis_elements.bind();
-        axis_elements.allocate(axis_elements_a, sizeof(axis_elements_a));
+        axis_elements.allocate(axis_elements_a.data(), sizeof(GLushort) * axis_elements_a.size());
       }
 
     }

--- a/lib/ome/qtwidgets/gl/Axis2D.cpp
+++ b/lib/ome/qtwidgets/gl/Axis2D.cpp
@@ -48,7 +48,7 @@ namespace ome
     namespace gl
     {
 
-      Axis2D::Axis2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+      Axis2D::Axis2D(std::shared_ptr<ome::files::FormatReader>  reader,
                      ome::files::dimension_size_type                    series,
                      QObject                                                *parent):
         QObject(parent),

--- a/lib/ome/qtwidgets/gl/Axis2D.h
+++ b/lib/ome/qtwidgets/gl/Axis2D.h
@@ -39,6 +39,8 @@
 #ifndef OME_QTWIDGETS_GL_AXIS2D_H
 #define OME_QTWIDGETS_GL_AXIS2D_H
 
+#include <memory>
+
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLVertexArrayObject>
 #include <QtGui/QOpenGLBuffer>
@@ -47,8 +49,6 @@
 
 #include <ome/files/Types.h>
 #include <ome/files/FormatReader.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/glm.h>
 
@@ -78,7 +78,7 @@ namespace ome
          * @param series the image series.
          * @param parent the parent of this object.
          */
-        explicit Axis2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+        explicit Axis2D(std::shared_ptr<ome::files::FormatReader>  reader,
                         ome::files::dimension_size_type                    series,
                         QObject                                                *parent = 0);
 
@@ -130,7 +130,7 @@ namespace ome
         /// The elements for both axes.
         QOpenGLBuffer axis_elements;
         /// The image reader.
-        ome::compat::shared_ptr<ome::files::FormatReader> reader;
+        std::shared_ptr<ome::files::FormatReader> reader;
         /// The image series.
         ome::files::dimension_size_type series;
       };

--- a/lib/ome/qtwidgets/gl/Grid2D.cpp
+++ b/lib/ome/qtwidgets/gl/Grid2D.cpp
@@ -39,7 +39,7 @@
 #include <ome/qtwidgets/gl/Grid2D.h>
 #include <ome/qtwidgets/gl/Util.h>
 
-#include <ome/compat/array.h>
+#include <array>
 #include <cmath>
 #include <iostream>
 
@@ -136,7 +136,7 @@ namespace ome
       Grid2D::setSize(const glm::vec2& xlim,
                       const glm::vec2& ylim)
       {
-        ome::compat::array<glm::vec3, 3> gridcol;
+        std::array<glm::vec3, 3> gridcol;
         gridcol[0] = glm::vec3(0.5f, 0.5f, 0.5f);
         gridcol[1] = glm::vec3(0.7f, 0.7f, 0.7f);
         gridcol[2] = glm::vec3(0.9f, 0.9f, 0.9f);

--- a/lib/ome/qtwidgets/gl/Grid2D.cpp
+++ b/lib/ome/qtwidgets/gl/Grid2D.cpp
@@ -106,7 +106,7 @@ namespace ome
     namespace gl
     {
 
-      Grid2D::Grid2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+      Grid2D::Grid2D(std::shared_ptr<ome::files::FormatReader>  reader,
                      ome::files::dimension_size_type                    series,
                      QObject                                                *parent):
         QObject(parent),

--- a/lib/ome/qtwidgets/gl/Grid2D.h
+++ b/lib/ome/qtwidgets/gl/Grid2D.h
@@ -39,6 +39,8 @@
 #ifndef OME_QTWIDGETS_GL_GRID2D_H
 #define OME_QTWIDGETS_GL_GRID2D_H
 
+#include <memory>
+
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLVertexArrayObject>
 #include <QtGui/QOpenGLBuffer>
@@ -47,8 +49,6 @@
 
 #include <ome/files/Types.h>
 #include <ome/files/FormatReader.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/glm.h>
 
@@ -79,7 +79,7 @@ namespace ome
          * @param series the image series.
          * @param parent the parent of this object.
          */
-        explicit Grid2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+        explicit Grid2D(std::shared_ptr<ome::files::FormatReader>  reader,
                         ome::files::dimension_size_type                    series,
                         QObject                                                *parent = 0);
 
@@ -130,7 +130,7 @@ namespace ome
         /// The elements for the grid.
         QOpenGLBuffer grid_elements;
         /// The image reader.
-        ome::compat::shared_ptr<ome::files::FormatReader> reader;
+        std::shared_ptr<ome::files::FormatReader> reader;
         /// The image series.
         ome::files::dimension_size_type series;
       };

--- a/lib/ome/qtwidgets/gl/Image2D.cpp
+++ b/lib/ome/qtwidgets/gl/Image2D.cpp
@@ -257,7 +257,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, void
       >::type
-    operator() (const ome::compat::shared_ptr<PixelBuffer<T> >& v)
+    operator() (const std::shared_ptr<PixelBuffer<T> >& v)
     {
       /// @todo Conversion from complex.
     }
@@ -273,7 +273,7 @@ namespace ome
     namespace gl
     {
 
-      Image2D::Image2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+      Image2D::Image2D(std::shared_ptr<ome::files::FormatReader>  reader,
                        ome::files::dimension_size_type                    series,
                        QObject                                                *parent):
         QObject(parent),

--- a/lib/ome/qtwidgets/gl/Image2D.cpp
+++ b/lib/ome/qtwidgets/gl/Image2D.cpp
@@ -257,7 +257,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, void
       >::type
-    operator() (const std::shared_ptr<PixelBuffer<T> >& v)
+    operator() (const std::shared_ptr<PixelBuffer<T>>& v)
     {
       /// @todo Conversion from complex.
     }

--- a/lib/ome/qtwidgets/gl/Image2D.cpp
+++ b/lib/ome/qtwidgets/gl/Image2D.cpp
@@ -257,7 +257,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, void
       >::type
-    operator() (const std::shared_ptr<PixelBuffer<T>>& v)
+    operator() (const std::shared_ptr<PixelBuffer<T>>& /* v */)
     {
       /// @todo Conversion from complex.
     }
@@ -377,7 +377,8 @@ namespace ome
       Image2D::setSize(const glm::vec2& xlim,
                        const glm::vec2& ylim)
       {
-        GLfloat square_vertices[] = {
+        const std::array<GLfloat, 8> square_vertices
+        {
           xlim[0], ylim[0],
           xlim[1], ylim[0],
           xlim[1], ylim[1],
@@ -392,11 +393,12 @@ namespace ome
           image_vertices.create();
         image_vertices.setUsagePattern(QOpenGLBuffer::StaticDraw);
         image_vertices.bind();
-        image_vertices.allocate(square_vertices, sizeof(square_vertices));
+        image_vertices.allocate(square_vertices.data(), sizeof(GLfloat) * square_vertices.size());
 
         glm::vec2 texxlim(0.0, 1.0);
         glm::vec2 texylim(0.0, 1.0);
-        GLfloat square_texcoords[] = {
+        std::array<GLfloat, 8> square_texcoords
+        {
           texxlim[0], texylim[0],
           texxlim[1], texylim[0],
           texxlim[1], texylim[1],
@@ -407,9 +409,10 @@ namespace ome
           image_texcoords.create();
         image_texcoords.setUsagePattern(QOpenGLBuffer::StaticDraw);
         image_texcoords.bind();
-        image_texcoords.allocate(square_texcoords, sizeof(square_texcoords));
+        image_texcoords.allocate(square_texcoords.data(), sizeof(GLfloat) * square_texcoords.size());
 
-        GLushort square_elements[] = {
+        std::array<GLushort, 6> square_elements
+        {
           // front
           0,  1,  2,
           2,  3,  0
@@ -419,7 +422,7 @@ namespace ome
           image_elements.create();
         image_elements.setUsagePattern(QOpenGLBuffer::StaticDraw);
         image_elements.bind();
-        image_elements.allocate(square_elements, sizeof(square_elements));
+        image_elements.allocate(square_elements.data(), sizeof(GLushort) * square_elements.size());
       }
 
       void

--- a/lib/ome/qtwidgets/gl/Image2D.h
+++ b/lib/ome/qtwidgets/gl/Image2D.h
@@ -39,6 +39,8 @@
 #ifndef OME_QTWIDGETS_GL_IMAGE2D_H
 #define OME_QTWIDGETS_GL_IMAGE2D_H
 
+#include <memory>
+
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLVertexArrayObject>
 #include <QtGui/QOpenGLBuffer>
@@ -47,8 +49,6 @@
 
 #include <ome/files/Types.h>
 #include <ome/files/FormatReader.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/glm.h>
 
@@ -83,7 +83,7 @@ namespace ome
          * @param parent the parent of this object.
          */
         explicit
-        Image2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+        Image2D(std::shared_ptr<ome::files::FormatReader>  reader,
                 ome::files::dimension_size_type                    series,
                 QObject                                                *parent = 0);
 
@@ -222,7 +222,7 @@ namespace ome
         /// Linear contrast correction multipliers.
         glm::vec3 texcorr;
         /// The image reader.
-        ome::compat::shared_ptr<ome::files::FormatReader> reader;
+        std::shared_ptr<ome::files::FormatReader> reader;
         /// The image series.
         ome::files::dimension_size_type series;
         /// The current image plane.

--- a/lib/ome/qtwidgets/gl/v33/V33Axis2D.cpp
+++ b/lib/ome/qtwidgets/gl/v33/V33Axis2D.cpp
@@ -50,7 +50,7 @@ namespace ome
       namespace v33
       {
 
-        Axis2D::Axis2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+        Axis2D::Axis2D(std::shared_ptr<ome::files::FormatReader>  reader,
                        ome::files::dimension_size_type                    series,
                        QObject                                           *parent):
           gl::Axis2D(reader, series, parent),

--- a/lib/ome/qtwidgets/gl/v33/V33Axis2D.h
+++ b/lib/ome/qtwidgets/gl/v33/V33Axis2D.h
@@ -77,7 +77,7 @@ namespace ome
            * @param series the image series.
            * @param parent the parent of this object.
            */
-          explicit Axis2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+          explicit Axis2D(std::shared_ptr<ome::files::FormatReader>  reader,
                           ome::files::dimension_size_type                    series,
                           QObject                                           *parent = 0);
 

--- a/lib/ome/qtwidgets/gl/v33/V33Grid2D.cpp
+++ b/lib/ome/qtwidgets/gl/v33/V33Grid2D.cpp
@@ -50,7 +50,7 @@ namespace ome
       namespace v33
       {
 
-        Grid2D::Grid2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+        Grid2D::Grid2D(std::shared_ptr<ome::files::FormatReader>  reader,
                        ome::files::dimension_size_type                    series,
                        QObject                                           *parent):
           gl::Grid2D(reader, series, parent),

--- a/lib/ome/qtwidgets/gl/v33/V33Grid2D.h
+++ b/lib/ome/qtwidgets/gl/v33/V33Grid2D.h
@@ -77,7 +77,7 @@ namespace ome
            * @param series the image series.
            * @param parent the parent of this object.
            */
-          explicit Grid2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+          explicit Grid2D(std::shared_ptr<ome::files::FormatReader>  reader,
                           ome::files::dimension_size_type                    series,
                           QObject                                           *parent = 0);
 

--- a/lib/ome/qtwidgets/gl/v33/V33Image2D.cpp
+++ b/lib/ome/qtwidgets/gl/v33/V33Image2D.cpp
@@ -50,7 +50,7 @@ namespace ome
       namespace v33
       {
 
-        Image2D::Image2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+        Image2D::Image2D(std::shared_ptr<ome::files::FormatReader>  reader,
                          ome::files::dimension_size_type                    series,
                          QObject                                           *parent):
           gl::Image2D(reader, series, parent),

--- a/lib/ome/qtwidgets/gl/v33/V33Image2D.h
+++ b/lib/ome/qtwidgets/gl/v33/V33Image2D.h
@@ -82,7 +82,7 @@ namespace ome
            * @param series the image series.
            * @param parent the parent of this object.
            */
-          explicit Image2D(ome::compat::shared_ptr<ome::files::FormatReader>  reader,
+          explicit Image2D(std::shared_ptr<ome::files::FormatReader>  reader,
                            ome::files::dimension_size_type                    series,
                            QObject                                           *parent = 0);
 

--- a/libexec/view/Window.cpp
+++ b/libexec/view/Window.cpp
@@ -42,9 +42,9 @@
 #include <ome/files/FormatReader.h>
 #include <ome/files/in/OMETIFFReader.h>
 
-#include <view/Window.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <view/Window.h>
 
 #include <ome/common/module.h>
 
@@ -245,7 +245,7 @@ namespace view
     QFileInfo info(file);
     if (info.exists())
       {
-        ome::compat::shared_ptr<ome::files::FormatReader> reader(ome::compat::make_shared<ome::files::in::OMETIFFReader>());
+        std::shared_ptr<ome::files::FormatReader> reader(std::make_shared<ome::files::in::OMETIFFReader>());
         reader->setId(file.toStdString());
         GLView2D *newGlView = new GLView2D(reader, 0, this);
         QWidget *glContainer = new GLContainer(this, newGlView);
@@ -293,7 +293,7 @@ namespace view
       }
     else
       {
-        navigation->setReader(ome::compat::shared_ptr<ome::files::FormatReader>(), 0, 0);
+        navigation->setReader(std::shared_ptr<ome::files::FormatReader>(), 0, 0);
       }
 
     bool enable(newGlView != 0);


### PR DESCRIPTION
Next part of [Minimal C++11 features](https://trello.com/c/h4pHPV2h/42-minimal-c-11-features) after https://github.com/ome/ome-common-cpp/pull/31.  This PR switches to using a few simple C++11 features.

- Use `<array>`, `<cstdint>`, `<memory>` and `<tuple>` in place of `<ome/compat/array.h>`, `<ome/compat/cstdint.h>`, `<ome/compat/memory.h>` and `<ome/compat/tuple.h>`, respectively (with namespace change from `ome::compat` to `std` for the corresponding types)
- Use `>>` in place of `> >` in templates (spaces previously required)
- Use `<::` in place of `< ::` (spaces previously required)
- Use initialiser lists when constructing objects, mainly containers.  This uses `foo{elem1, elem2, elemn}` in place of `foo` to directly fill containers with elements.  Mainly used with parameterised test data which had to use static arrays as the data source.
- Use range-based for loop and `auto` type rather than manually define complex iterator types and manually iterate; this greatly simplifies `for` loops
- Use `enum class` to scope enum values; previously they leaked into the enclosing scope
- Use C++11 type traits in place of Boost type traits
- Use `std::vector`'s `.data` method to pass arrays to C calls as a raw pointer

--------

Testing: Check all builds are green.