### PR TITLE
Bump release version to 5.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ list(APPEND CMAKE_MODULE_PATH
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/BioFormatsCommon.cmake")
 
 set(release-name "ome-qtwidgets")
-set(release-version "5.4.0")
+set(release-version "5.4.1")
 project("${release-name}"
         VERSION "${release-version}"
         LANGUAGES CXX)


### PR DESCRIPTION
Similarly to the `ome-common-cpp:5.4.1` and `ome-model:5.5.3` patch releases, this PR increments the minor version number of `ome-qtwidgets` with the Boost 1.64 support addition.