### PR TITLE
Add Dockerfile to build ome-widgets and enable Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+services: docker
+
+env:
+    - PLATFORM=u1604
+    - PLATFORM=c7
+
+script: docker build -t ome-qtwidgets -f docker/${PLATFORM}/Dockerfile .

--- a/docker/c7/Dockerfile
+++ b/docker/c7/Dockerfile
@@ -1,0 +1,20 @@
+FROM openmicroscopy/ome-files-cpp-c7
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN yum -y install \
+    qt5-qtbase-devel \
+    qt5-qtsvg-devel \
+    glm-devel
+
+COPY . /git/ome-qtwidgets
+
+RUN cmake3 \
+    -Dgit-dir=/git \
+    -Dbuild-prerequisites=OFF \
+    -Dome-superbuild_BUILD_gtest=ON \
+    -Dbuild-packages=ome-qtwidgets \
+    -DCMAKE_BUILD_TYPE=Release \
+    /git/ome-cmake-superbuild
+RUN make
+RUN make install
+RUN ldconfig

--- a/docker/u1604/Dockerfile
+++ b/docker/u1604/Dockerfile
@@ -1,0 +1,21 @@
+FROM openmicroscopy/ome-files-cpp-u1604
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN apt-get -y install \
+    qt5-default \
+    libqt5opengl5-dev \
+    libqt5svg5-dev \
+    libglm-dev
+
+COPY . /git/ome-qtwidgets
+
+RUN cmake \
+    -Dgit-dir=/git \
+    -Dbuild-prerequisites=OFF \
+    -Dome-superbuild_BUILD_gtest=ON \
+    -Dbuild-packages=ome-qtwidgets \
+    -DCMAKE_BUILD_TYPE=Release \
+    /git/ome-cmake-superbuild
+RUN make
+RUN make install
+RUN ldconfig


### PR DESCRIPTION
See https://github.com/ome/ome-cmake-superbuild/pull/161

Following the [C7 platform support addition](https://github.com/openmicroscopy/ome-files-cpp-c7-docker/pull/2), this PR adds two Dockerfile under `docker/c7` and `docker/u1604` using the corresponding OME Files C++ base images and installing the ome-qtwidgets prerequisites.

A new .travis.yml file is also added that build each Dockerfile in a separate matrix job.

To test this PR, check Travis is green for both platforms.

NB: I used `docker/${PLATFORM}/Dockerfile` together with `docker build -f` although we might discuss homogenizing the naming across the board. /cc @joshmoore @jburel  