### PR TITLE
cmake: Remove REQUIRED from exported configuration

### DIFF
--- a/lib/ome/qtwidgets/OMEQtWidgetsConfig.cmake.in
+++ b/lib/ome/qtwidgets/OMEQtWidgetsConfig.cmake.in
@@ -1,11 +1,11 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(OMECommon REQUIRED)
-find_dependency(OMEXML REQUIRED)
-find_dependency(OMEFiles REQUIRED)
-find_dependency(Boost 1.46 REQUIRED COMPONENTS boost iostreams filesystem)
-find_dependency(TIFF REQUIRED)
+find_dependency(OMECommon)
+find_dependency(OMEXML)
+find_dependency(OMEFiles)
+find_dependency(Boost 1.46 COMPONENTS boost iostreams filesystem)
+find_dependency(TIFF)
 
 include(${CMAKE_CURRENT_LIST_DIR}/OMEQtWidgetsInternal.cmake)
 


### PR DESCRIPTION
This is added implicitly by find_dependency.

See https://github.com/ome/ome-common-cpp/pull/51 for context.