### PR TITLE
glm.h: Set GLM_ENABLE_EXPERIMENTAL for glm/gtx/rotate_vector

### DIFF
--- a/lib/ome/qtwidgets/glm.h
+++ b/lib/ome/qtwidgets/glm.h
@@ -40,6 +40,7 @@
 #define OME_QTWIDGETS_GLM_H
 
 #define GLM_FORCE_RADIANS
+#define GLM_ENABLE_EXPERIMENTAL
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>


### PR DESCRIPTION
Required for new versions of the GLM library, due to this extra check:

https://github.com/g-truc/glm/blob/0.9.9-a2/glm/gtx/rotate_vector.hpp#L20

Without this fix, it's not possible to build with current glm releases.

Testing: Check builds are green.  The MacOS X node (snipe) and FreeBSD node (perch) require the fix.  Ubuntu 18.04 also requires the fix, along with any other platforms providing a recent glm release.