### PR TITLE
build: Link using imported targets

### DIFF
--- a/lib/ome/qtwidgets/CMakeLists.txt
+++ b/lib/ome/qtwidgets/CMakeLists.txt
@@ -104,7 +104,6 @@ add_library(ome-qtwidgets
             ${QTWIDGETS_GLSL_V330_HEADERS}
             ${ome-qtwidgets_HEADERS_MOC}
             ${ome-qtwidgets_RESOURCES})
-qt5_use_modules(ome-qtwidgets Core Gui Widgets Svg)
 
 target_include_directories(ome-qtwidgets PUBLIC
                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
@@ -114,6 +113,7 @@ target_include_directories(ome-qtwidgets PUBLIC
 
 target_link_libraries(ome-qtwidgets OME::Files
                       Boost::filesystem
+                      Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Svg
                       ${OPENGL_gl_LIBRARY} ${TIFF_LIBRARIES})
 
 set_target_properties(ome-qtwidgets PROPERTIES VERSION ${ome-qtwidgets_VERSION})

--- a/libexec/view/CMakeLists.txt
+++ b/libexec/view/CMakeLists.txt
@@ -50,7 +50,6 @@ add_executable(view
                ${view_HEADERS_MOC}
                ${view_RESOURCES})
 
-qt5_use_modules(view Core Gui Widgets Svg)
 
 target_include_directories(view PUBLIC
                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/libexec>
@@ -58,7 +57,7 @@ target_include_directories(view PUBLIC
                            $<BUILD_INTERFACE:${OPENGL_INCLUDE_DIR}>
                            $<BUILD_INTERFACE:${GLM_INCLUDE_DIR}>)
 
-target_link_libraries(view OME::Files OME::QtWidgets)
+target_link_libraries(view OME::Files OME::QtWidgets Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Svg)
 
 install(TARGETS view RUNTIME
         DESTINATION ${OME_QTWIDGETS_INSTALL_PKGLIBEXECDIR}

--- a/test/ome-qtwidgets/CMakeLists.txt
+++ b/test/ome-qtwidgets/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_TESTS)
 
   if(extended-tests)
     header_test_from_file(ome-qtwidgets ome-qtwidgets ome/qtwidgets)
-    qt5_use_modules(ome-qtwidgets-headers Core Gui Widgets Svg)
+    target_link_libraries(ome-qtwidgets-headers Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Svg)
     ome_files_add_test(ome-qtwidgets/headers ome-qtwidgets-headers)
   endif(extended-tests)
 


### PR DESCRIPTION
Required by Qt 5.11, which drops support for the older `qt5_use_modules` function.

Testing: Check builds are green.